### PR TITLE
Inject Develocity plugin via GitHub action

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
@@ -28,6 +28,9 @@ if (isTopLevelBuild) {
             settings.pluginManager.withPlugin("com.gradle.enterprise") {
                 captureUsingBuildScanPublished(settings.extensions["gradleEnterprise"].buildScan, settings.rootProject, invocationId)
             }
+            settings.pluginManager.withPlugin("com.gradle.develocity") {
+                captureUsingBuildScanPublished(settings.extensions["develocity"].buildScan, settings.rootProject, invocationId)
+            }
         }
     } else if (atLeastGradle3) {
         projectsEvaluated { gradle ->

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -24,6 +24,7 @@ initscript {
     def develocityPluginVersion = getInputParam('develocity.plugin.version')
     def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 
+    def shouldApplyDevelocityPlugin = GradleVersion.version(develocityPluginVersion) >= GradleVersion.version("3.17")
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
@@ -39,8 +40,8 @@ initscript {
     dependencies {
         if (develocityPluginVersion) {
             classpath atLeastGradle5 ?
-                "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion" :
-                "com.gradle:build-scan-plugin:1.16"
+                    shouldApplyDevelocityPlugin ? "com.gradle:develocity-gradle-plugin:$develocityPluginVersion" : "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion" :
+                    "com.gradle:build-scan-plugin:1.16"
         }
 
         if (ccudPluginVersion && atLeastGradle4) {
@@ -54,7 +55,14 @@ def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
 def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
 def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+
+def DEVELOCITY_PLUGIN_ID = 'com.gradle.develocity'
+def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.develocity.agent.gradle.DevelocityPlugin'
+def SETTINGS_EXTENSION_CLASSES = [
+        'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension',
+        'com.gradle.develocity.agent.gradle.DevelocityConfiguration'
+]
+
 def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
 def CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE = 'gradle-actions'
 def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
@@ -85,7 +93,16 @@ def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
 def buildScanTermsOfServiceAgree = getInputParam('build-scan.terms-of-service.agree')
 
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
+def shouldApplyDevelocityPlugin = atLeastGradle5 && isAtLeast(develocityPluginVersion, '3.17')
+
+def dvOrGe = { def dvValue, def geValue ->
+    if (shouldApplyDevelocityPlugin) {
+        return dvValue instanceof Closure<?> ? dvValue() : dvValue
+    }
+    return geValue instanceof Closure<?> ? geValue() : geValue
+}
 
 // finish early if configuration parameters passed in via system properties are not valid/supported
 if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
@@ -101,34 +118,57 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (develocityPluginVersion) {
                 def scanPluginComponent = resolutionResult.allComponents.find {
-                    it.moduleVersion.with { group == "com.gradle" && (name == "build-scan-plugin" || name == "gradle-enterprise-gradle-plugin") }
+                    it.moduleVersion.with { group == "com.gradle" && ['build-scan-plugin', 'gradle-enterprise-gradle-plugin', 'develocity-gradle-plugin'].contains(name) }
                 }
                 if (!scanPluginComponent) {
-                    logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
-                    applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
+                    def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, BUILD_SCAN_PLUGIN_CLASS)
+                    logger.quiet("Applying $pluginClass via init script")
+                    applyPluginExternally(pluginManager, pluginClass)
+                    def rootExtension = dvOrGe(
+                            { develocity },
+                            { buildScan }
+                    )
+                    def buildScanExtension = dvOrGe(
+                            { rootExtension.buildScan },
+                            { rootExtension }
+                    )
                     if (develocityUrl) {
                         logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
-                        buildScan.server = develocityUrl
-                        buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                        rootExtension.server = develocityUrl
+                        rootExtension.allowUntrustedServer = develocityAllowUntrustedServer
                     }
-                    buildScan.publishAlways()
-                    if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
-                    buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                    if (!shouldApplyDevelocityPlugin) {
+                        // Develocity plugin publishes scans by default
+                        buildScanExtension.publishAlways()
+                    }
+                    // uploadInBackground not available for build-scan-plugin 1.16
+                    if (buildScanExtension.metaClass.respondsTo(buildScanExtension, 'setUploadInBackground', Boolean)) buildScanExtension.uploadInBackground = buildScanUploadInBackground
+                    buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
                             buildScan.server = develocityUrl
                             buildScan.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
+                    }
+                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                        afterEvaluate {
+                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Develocity plugin")
+                            develocity.server = develocityUrl
+                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
                     }
                 }
 
                 if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
-                    buildScan.termsOfServiceUrl = buildScanTermsOfServiceUrl
-                    buildScan.termsOfServiceAgree = buildScanTermsOfServiceAgree
+                    def buildScanExtension = atLeastGradle5
+                            ? dvOrGe(develocity.buildScan, buildScan)
+                            : buildScan
+                    buildScanExtension.termsOfServiceUrl = buildScanTermsOfServiceUrl
+                    buildScanExtension.termsOfServiceAgree = buildScanTermsOfServiceAgree
                 }
             }
 
@@ -146,23 +186,27 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 } else {
     gradle.settingsEvaluated { settings ->
         if (develocityPluginVersion) {
-            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
-                logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
-                applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
-                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
+            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID) && !settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
+                def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                logger.quiet("Applying $pluginClass via init script")
+                applyPluginExternally(settings.pluginManager, pluginClass)
+                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
                     if (develocityUrl) {
                         logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                         ext.server = develocityUrl
                         ext.allowUntrustedServer = develocityAllowUntrustedServer
                     }
-                    ext.buildScan.publishAlways()
+                    if (!shouldApplyDevelocityPlugin) {
+                        // Develocity plugin publishes build scans by default
+                        ext.buildScan.publishAlways()
+                    }
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
             }
 
             if (develocityUrl && develocityEnforceUrl) {
-                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
+                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
                     logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                     ext.server = develocityUrl
                     ext.allowUntrustedServer = develocityAllowUntrustedServer
@@ -170,7 +214,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             }
 
             if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
-                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
+                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
                     ext.buildScan.termsOfServiceUrl = buildScanTermsOfServiceUrl
                     ext.buildScan.termsOfServiceAgree = buildScanTermsOfServiceAgree
                 }
@@ -201,11 +245,16 @@ void applyPluginExternally(def pluginManager, String pluginClassName) {
     }
 }
 
-static def eachDevelocityExtension(def settings, def publicType, def action) {
-    settings.extensions.extensionsSchema.elements.findAll { it.publicType.concreteClass.name == publicType }
-        .collect { settings[it.name] }.each(action)
+static def eachDevelocitySettingsExtension(def settings, List<String> publicTypes, def action) {
+    settings.extensions.extensionsSchema.elements.findAll { publicTypes.contains(it.publicType.concreteClass.name) }
+            .collect { settings[it.name] }
+            .each(action)
+}
+
+static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
+    GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
 }
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
-    GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+    !isAtLeast(versionUnderTest, referenceVersion)
 }

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -146,28 +146,33 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScanExtension.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
 
-                if (develocityUrl && develocityEnforceUrl) {
-                    logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
-                    pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
-                        afterEvaluate {
+                pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
+                    afterEvaluate {
+                        if (develocityUrl && develocityEnforceUrl) {
+                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
                             buildScan.server = develocityUrl
                             buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                         }
-                    }
-                    pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
-                        afterEvaluate {
-                            develocity.server = develocityUrl
-                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
+
+                        if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
+                            buildScan.termsOfServiceUrl = buildScanTermsOfServiceUrl
+                            buildScan.termsOfServiceAgree = buildScanTermsOfServiceAgree
                         }
                     }
                 }
+                pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
+                    afterEvaluate {
+                        if (develocityUrl && develocityEnforceUrl) {
+                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
+                            develocity.server = develocityUrl
+                            develocity.allowUntrustedServer = develocityAllowUntrustedServer
+                        }
 
-                if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
-                    def buildScanExtension = atLeastGradle5
-                            ? dvOrGe(develocity.buildScan, buildScan)
-                            : buildScan
-                    buildScanExtension.termsOfServiceUrl = buildScanTermsOfServiceUrl
-                    buildScanExtension.termsOfServiceAgree = buildScanTermsOfServiceAgree
+                        if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
+                            develocity.buildScan.termsOfServiceUrl = buildScanTermsOfServiceUrl
+                            develocity.buildScan.termsOfServiceAgree = buildScanTermsOfServiceAgree
+                        }
+                    }
                 }
             }
 

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 
 // note that there is no mechanism to share code between the initscript{} block and the main script, so some logic is duplicated
 
-// conditionally apply the GE / Build Scan plugin to the classpath so it can be applied to the build further down in this script
+// conditionally apply the Develocity plugin to the classpath so it can be applied to the build further down in this script
 initscript {
     def isTopLevelBuild = !gradle.parent
     if (!isTopLevelBuild) {
@@ -21,13 +21,13 @@ initscript {
     }
 
     def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url')
-    def gePluginVersion = getInputParam('develocity.plugin.version')
+    def develocityPluginVersion = getInputParam('develocity.plugin.version')
     def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 
     def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
     def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
-    if (gePluginVersion || ccudPluginVersion && atLeastGradle4) {
+    if (develocityPluginVersion || ccudPluginVersion && atLeastGradle4) {
         pluginRepositoryUrl = pluginRepositoryUrl ?: 'https://plugins.gradle.org/m2'
         logger.quiet("Develocity plugins resolution: $pluginRepositoryUrl")
 
@@ -37,9 +37,9 @@ initscript {
     }
 
     dependencies {
-        if (gePluginVersion) {
+        if (develocityPluginVersion) {
             classpath atLeastGradle5 ?
-                "com.gradle:gradle-enterprise-gradle-plugin:$gePluginVersion" :
+                "com.gradle:gradle-enterprise-gradle-plugin:$develocityPluginVersion" :
                 "com.gradle:build-scan-plugin:1.16"
         }
 
@@ -52,9 +52,9 @@ initscript {
 def BUILD_SCAN_PLUGIN_ID = 'com.gradle.build-scan'
 def BUILD_SCAN_PLUGIN_CLASS = 'com.gradle.scan.plugin.BuildScanPlugin'
 
-def DEVELOCITY_PLUGIN_ID = 'com.gradle.enterprise'
-def DEVELOCITY_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
-def DEVELOCITY_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
+def GRADLE_ENTERPRISE_PLUGIN_ID = 'com.gradle.enterprise'
+def GRADLE_ENTERPRISE_PLUGIN_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin'
+def GRADLE_ENTERPRISE_EXTENSION_CLASS = 'com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension'
 def CI_AUTO_INJECTION_CUSTOM_VALUE_NAME = 'CI auto injection'
 def CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE = 'gradle-actions'
 def CCUD_PLUGIN_ID = 'com.gradle.common-custom-user-data-gradle-plugin'
@@ -76,11 +76,11 @@ if (gradleInjectionEnabled != "true") {
     return
 }
 
-def geUrl = getInputParam('develocity.url')
-def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
-def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
+def develocityUrl = getInputParam('develocity.url')
+def develocityAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
+def develocityEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def gePluginVersion = getInputParam('develocity.plugin.version')
+def develocityPluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
 def buildScanTermsOfServiceAgree = getInputParam('build-scan.terms-of-service.agree')
@@ -93,35 +93,35 @@ if (ccudPluginVersion && isNotAtLeast(ccudPluginVersion, '1.7')) {
     return
 }
 
-// register buildScanPublished listener and optionally apply the GE / Build Scan plugin
+// register buildScanPublished listener and optionally apply the Develocity plugin
 if (GradleVersion.current() < GradleVersion.version('6.0')) {
     rootProject {
         buildscript.configurations.getByName("classpath").incoming.afterResolve { ResolvableDependencies incoming ->
             def resolutionResult = incoming.resolutionResult
 
-            if (gePluginVersion) {
+            if (develocityPluginVersion) {
                 def scanPluginComponent = resolutionResult.allComponents.find {
                     it.moduleVersion.with { group == "com.gradle" && (name == "build-scan-plugin" || name == "gradle-enterprise-gradle-plugin") }
                 }
                 if (!scanPluginComponent) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
-                    if (geUrl) {
-                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                        buildScan.server = geUrl
-                        buildScan.allowUntrustedServer = geAllowUntrustedServer
+                    if (develocityUrl) {
+                        logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                        buildScan.server = develocityUrl
+                        buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                     }
                     buildScan.publishAlways()
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
 
-                if (geUrl && geEnforceUrl) {
+                if (develocityUrl && develocityEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                            buildScan.server = geUrl
-                            buildScan.allowUntrustedServer = geAllowUntrustedServer
+                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                            buildScan.server = develocityUrl
+                            buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                         }
                     }
                 }
@@ -145,15 +145,15 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
     }
 } else {
     gradle.settingsEvaluated { settings ->
-        if (gePluginVersion) {
-            if (!settings.pluginManager.hasPlugin(DEVELOCITY_PLUGIN_ID)) {
-                logger.quiet("Applying $DEVELOCITY_PLUGIN_CLASS via init script")
-                applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
-                eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    if (geUrl) {
-                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                        ext.server = geUrl
-                        ext.allowUntrustedServer = geAllowUntrustedServer
+        if (develocityPluginVersion) {
+            if (!settings.pluginManager.hasPlugin(GRADLE_ENTERPRISE_PLUGIN_ID)) {
+                logger.quiet("Applying $GRADLE_ENTERPRISE_PLUGIN_CLASS via init script")
+                applyPluginExternally(settings.pluginManager, GRADLE_ENTERPRISE_PLUGIN_CLASS)
+                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
+                    if (develocityUrl) {
+                        logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                        ext.server = develocityUrl
+                        ext.allowUntrustedServer = develocityAllowUntrustedServer
                     }
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
@@ -161,16 +161,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
             }
 
-            if (geUrl && geEnforceUrl) {
-                eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
-                    ext.server = geUrl
-                    ext.allowUntrustedServer = geAllowUntrustedServer
+            if (develocityUrl && develocityEnforceUrl) {
+                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
+                    logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                    ext.server = develocityUrl
+                    ext.allowUntrustedServer = develocityAllowUntrustedServer
                 }
             }
 
             if (buildScanTermsOfServiceUrl && buildScanTermsOfServiceAgree) {
-                eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
+                eachDevelocityExtension(settings, GRADLE_ENTERPRISE_EXTENSION_CLASS) { ext ->
                     ext.buildScan.termsOfServiceUrl = buildScanTermsOfServiceUrl
                     ext.buildScan.termsOfServiceAgree = buildScanTermsOfServiceAgree
                 }

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -147,16 +147,15 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 }
 
                 if (develocityUrl && develocityEnforceUrl) {
+                    logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Build Scan plugin")
                             buildScan.server = develocityUrl
                             buildScan.allowUntrustedServer = develocityAllowUntrustedServer
                         }
                     }
                     pluginManager.withPlugin(DEVELOCITY_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer for Develocity plugin")
                             develocity.server = develocityUrl
                             develocity.allowUntrustedServer = develocityAllowUntrustedServer
                         }
@@ -190,12 +189,15 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 def pluginClass = dvOrGe(DEVELOCITY_PLUGIN_CLASS, GRADLE_ENTERPRISE_PLUGIN_CLASS)
                 logger.quiet("Applying $pluginClass via init script")
                 applyPluginExternally(settings.pluginManager, pluginClass)
-                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
-                    if (develocityUrl) {
-                        logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                if (develocityUrl) {
+                    logger.quiet("Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
+                    eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
                         ext.server = develocityUrl
                         ext.allowUntrustedServer = develocityAllowUntrustedServer
                     }
+                }
+
+                eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
                     if (!shouldApplyDevelocityPlugin) {
                         // Develocity plugin publishes build scans by default
                         ext.buildScan.publishAlways()
@@ -206,8 +208,8 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
             }
 
             if (develocityUrl && develocityEnforceUrl) {
+                logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                 eachDevelocitySettingsExtension(settings, SETTINGS_EXTENSION_CLASSES) { ext ->
-                    logger.quiet("Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer")
                     ext.server = develocityUrl
                     ext.allowUntrustedServer = develocityAllowUntrustedServer
                 }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -129,12 +129,12 @@ class BaseInitScriptTest extends Specification {
         buildFile << ''
     }
 
-    def declareGePluginApplication(GradleVersion gradleVersion, URI serverUrl = mockScansServer.address) {
+    def declareDevelocityPluginApplication(GradleVersion gradleVersion, URI serverUrl = mockScansServer.address) {
         settingsFile.text = maybeAddPluginsToSettings(gradleVersion, null, serverUrl) + settingsFile.text
         buildFile.text = maybeAddPluginsToRootProject(gradleVersion, null, serverUrl) + buildFile.text
     }
 
-    def declareGePluginAndCcudPluginApplication(GradleVersion gradleVersion, URI serverUrl = mockScansServer.address) {
+    def declareDevelocityPluginAndCcudPluginApplication(GradleVersion gradleVersion, URI serverUrl = mockScansServer.address) {
         settingsFile.text = maybeAddPluginsToSettings(gradleVersion, CCUD_PLUGIN_VERSION, serverUrl) + settingsFile.text
         buildFile.text = maybeAddPluginsToRootProject(gradleVersion, CCUD_PLUGIN_VERSION, serverUrl) + buildFile.text
     }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -16,7 +16,7 @@ import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
 
 class BaseInitScriptTest extends Specification {
-    static final String DEVELOCITY_PLUGIN_VERSION = '3.16.2'
+    static final String DEVELOCITY_PLUGIN_VERSION = '3.17'
     static final String CCUD_PLUGIN_VERSION = '1.12.1'
 
     static final TestGradleVersion GRADLE_3_X = new TestGradleVersion(GradleVersion.version('3.5.1'), 7, 9)
@@ -140,22 +140,15 @@ class BaseInitScriptTest extends Specification {
     }
 
     String maybeAddPluginsToSettings(GradleVersion gradleVersion, String ccudPluginVersion, URI serverUri) {
-        if (gradleVersion < GradleVersion.version('5.0')) {
-            '' // applied in build.gradle
-        } else if (gradleVersion < GradleVersion.version('6.0')) {
+        if (gradleVersion < GradleVersion.version('6.0')) {
             '' // applied in build.gradle
         } else {
             """
               plugins {
-                id 'com.gradle.enterprise' version '${DEVELOCITY_PLUGIN_VERSION}'
+                id 'com.gradle.develocity' version '${DEVELOCITY_PLUGIN_VERSION}'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
-              gradleEnterprise {
-                server = '$serverUri'
-                buildScan {
-                  publishAlways()
-                }
-              }
+              develocity.server = '$serverUri'
             """
         }
     }
@@ -175,15 +168,10 @@ class BaseInitScriptTest extends Specification {
         } else if (gradleVersion < GradleVersion.version('6.0')) {
             """
               plugins {
-                id 'com.gradle.build-scan' version '${DEVELOCITY_PLUGIN_VERSION}'
+                id 'com.gradle.develocity' version '${DEVELOCITY_PLUGIN_VERSION}'
                 ${ccudPluginVersion ? "id 'com.gradle.common-custom-user-data-gradle-plugin' version '$ccudPluginVersion'" : ""}
               }
-              gradleEnterprise {
-                server = '$serverUrl'
-                buildScan {
-                  publishAlways()
-                }
-              }
+              develocity.server = '$serverUrl'
             """
         } else {
             '' // applied in settings.gradle

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
@@ -58,7 +58,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
         run(['help'], initScript, testGradleVersion.gradleVersion)
 
         then:
@@ -68,11 +68,11 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         testGradleVersion << ALL_VERSIONS
     }
 
-    def "produces build results file for #testGradleVersion with ge-plugin and no build scan published"() {
+    def "produces build results file for #testGradleVersion with Develocity plugin and no build scan published"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
         run(['help', '--no-scan'], initScript, testGradleVersion.gradleVersion)
 
         then:
@@ -86,7 +86,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
         addFailingTaskToBuild()
         runAndFail(['expectFailure'], initScript, testGradleVersion.gradleVersion)
 
@@ -101,7 +101,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
         run(['help', '--configuration-cache'], initScript, testGradleVersion.gradleVersion)
 
         then:
@@ -122,7 +122,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
         addFailingTaskToBuild()
         failScanUpload = true
         runAndFail(['expectFailure'], initScript, testGradleVersion.gradleVersion)
@@ -165,7 +165,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         testGradleVersion << ALL_VERSIONS
     }
 
-    def "produces build results file with build scan when GE plugin is applied in settingsEvaluated"() {
+    def "produces build results file with build scan when Develocity plugin is applied in settingsEvaluated"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -30,7 +30,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         given:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
 
         when:
         def result = run(testGradleVersion, testConfig())
@@ -84,7 +84,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         given:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
 
         when:
         def result = run(testGradleVersion, testConfig().withCCUDPlugin())
@@ -104,7 +104,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         given:
-        declareGePluginAndCcudPluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginAndCcudPluginApplication(testGradleVersion.gradleVersion)
 
         when:
         def result = run(testGradleVersion, testConfig().withCCUDPlugin())
@@ -124,7 +124,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         given:
-        declareGePluginApplication(testGradleVersion.gradleVersion)
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion)
 
         when:
         def config = testConfig().withServer(URI.create('https://develocity-server.invalid'))
@@ -165,7 +165,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         given:
-        declareGePluginApplication(testGradleVersion.gradleVersion, URI.create('https://develocity-server.invalid'))
+        declareDevelocityPluginApplication(testGradleVersion.gradleVersion, URI.create('https://develocity-server.invalid'))
 
         when:
         def config = testConfig().withServer(mockScansServer.address, true)
@@ -305,10 +305,10 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert !result.output.contains(pluginApplicationLogMsg)
     }
 
-    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
-        assert result.output.contains(geConnectionInfo)
-        assert 1 == result.output.count(geConnectionInfo)
+    void outputContainsDevelocityConnectionInfo(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
+        def develocityConnectionInfo = "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
+        assert result.output.contains(develocityConnectionInfo)
+        assert 1 == result.output.count(develocityConnectionInfo)
     }
 
     void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl) {
@@ -317,8 +317,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert 1 == result.output.count(repositoryInfo)
     }
 
-    void outputEnforcesDevelocityUrl(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
-        def enforceUrl = "Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
+    void outputEnforcesDevelocityUrl(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
+        def enforceUrl = "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
         assert result.output.contains(enforceUrl)
         assert 1 == result.output.count(enforceUrl)
     }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -5,12 +5,14 @@ import org.gradle.util.GradleVersion
 
 import static org.junit.Assume.assumeTrue
 
+// TODO pshevche: test that applying the GE plugin still works
+// TODO pshevche: test that deprecated plugins also prevent the DV plugin application
 class TestDevelocityInjection extends BaseInitScriptTest {
     static final List<TestGradleVersion> CCUD_COMPATIBLE_VERSIONS = ALL_VERSIONS - [GRADLE_3_X]
 
     def initScript = 'gradle-actions.inject-develocity.init.gradle'
 
-    private static final GradleVersion GRADLE_6 = GradleVersion.version('6.0')
+    private static final GradleVersion GRADLE_5 = GradleVersion.version('5.0')
 
     def "does not apply Develocity plugins when not requested"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
@@ -274,24 +276,24 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     }
 
     void outputContainsDevelocityPluginApplicationViaInitScript(BuildResult result, GradleVersion gradleVersion) {
-        def pluginApplicationLogMsgGradle4And5 = "Applying com.gradle.scan.plugin.BuildScanPlugin via init script"
-        def pluginApplicationLogMsgGradle6AndHigher = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin via init script"
-        if (gradleVersion < GRADLE_6) {
-            assert result.output.contains(pluginApplicationLogMsgGradle4And5)
-            assert 1 == result.output.count(pluginApplicationLogMsgGradle4And5)
-            assert !result.output.contains(pluginApplicationLogMsgGradle6AndHigher)
+        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin via init script"
+        def pluginApplicationLogMsgGradle5AndHigher = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin via init script"
+        if (gradleVersion < GRADLE_5) {
+            assert result.output.contains(pluginApplicationLogMsgGradle4)
+            assert 1 == result.output.count(pluginApplicationLogMsgGradle4)
+            assert !result.output.contains(pluginApplicationLogMsgGradle5AndHigher)
         } else {
-            assert result.output.contains(pluginApplicationLogMsgGradle6AndHigher)
-            assert 1 == result.output.count(pluginApplicationLogMsgGradle6AndHigher)
-            assert !result.output.contains(pluginApplicationLogMsgGradle4And5)
+            assert result.output.contains(pluginApplicationLogMsgGradle5AndHigher)
+            assert 1 == result.output.count(pluginApplicationLogMsgGradle5AndHigher)
+            assert !result.output.contains(pluginApplicationLogMsgGradle4)
         }
     }
 
     void outputMissesDevelocityPluginApplicationViaInitScript(BuildResult result) {
-        def pluginApplicationLogMsgGradle4And5 = "Applying com.gradle.scan.plugin.BuildScanPlugin via init script"
-        def pluginApplicationLogMsgGradle6AndHigher = "Applying com.gradle.enterprise.gradleplugin.GradleEnterprisePlugin via init script"
-        assert !result.output.contains(pluginApplicationLogMsgGradle4And5)
-        assert !result.output.contains(pluginApplicationLogMsgGradle6AndHigher)
+        def pluginApplicationLogMsgGradle4 = "Applying com.gradle.scan.plugin.BuildScanPlugin via init script"
+        def pluginApplicationLogMsgGradle5AndHigher = "Applying com.gradle.develocity.agent.gradle.DevelocityPlugin via init script"
+        assert !result.output.contains(pluginApplicationLogMsgGradle4)
+        assert !result.output.contains(pluginApplicationLogMsgGradle5AndHigher)
     }
 
     void outputContainsCcudPluginApplicationViaInitScript(BuildResult result) {
@@ -308,7 +310,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     void outputContainsDevelocityConnectionInfo(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
         def develocityConnectionInfo = "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
         assert result.output.contains(develocityConnectionInfo)
-        assert 1 == result.output.count(develocityConnectionInfo)
+        // Develocity plugin configures both the deprecated and new extensions
+        assert 2 == result.output.count(develocityConnectionInfo)
     }
 
     void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl) {
@@ -320,7 +323,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     void outputEnforcesDevelocityUrl(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
         def enforceUrl = "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
         assert result.output.contains(enforceUrl)
-        assert 1 == result.output.count(enforceUrl)
+        // Develocity plugin configures both the deprecated and new extensions
+        assert 2 == result.output.count(enforceUrl)
     }
 
     private BuildResult run(TestGradleVersion testGradleVersion, TestConfig config, List<String> args = ["help"]) {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -310,8 +310,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     void outputContainsDevelocityConnectionInfo(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
         def develocityConnectionInfo = "Connection to Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
         assert result.output.contains(develocityConnectionInfo)
-        // Develocity plugin configures both the deprecated and new extensions
-        assert 2 == result.output.count(develocityConnectionInfo)
+        assert 1 == result.output.count(develocityConnectionInfo)
     }
 
     void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl) {
@@ -323,8 +322,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     void outputEnforcesDevelocityUrl(BuildResult result, String develocityUrl, boolean develocityAllowUntrustedServer) {
         def enforceUrl = "Enforcing Develocity: $develocityUrl, allowUntrustedServer: $develocityAllowUntrustedServer"
         assert result.output.contains(enforceUrl)
-        // Develocity plugin configures both the deprecated and new extensions
-        assert 2 == result.output.count(enforceUrl)
+        assert 1 == result.output.count(enforceUrl)
     }
 
     private BuildResult run(TestGradleVersion testGradleVersion, TestConfig config, List<String> args = ["help"]) {


### PR DESCRIPTION
## Summary
To prepare for the upcoming rebranding of the GE plugin, this PR updates the `inject-develocity` init script to apply the `com.gradle.develocity` plugin if 3.17+ version of the plugin is requested. This PR should not be merged until the 3.17 version of the plugin is available on the Plugins portal. I verified the change by running tests against a locally built DV plugin. Some minor changes to tests and the script were necessary, but I don't think those are valuable to commit.