### PR TITLE
Fail nicely when dependency-submission is used after setup-gradle in the same Job

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -52,12 +52,13 @@ jobs:
     - name: Setup Gradle
       uses: ./setup-gradle
     - name: Generate and submit dependencies
+      id: dependency-submission
       uses: ./dependency-submission
       continue-on-error: true
       with:
         build-root-directory: .github/workflow-samples/groovy-dsl
     - name: Assert step failure
-      if: ${{ success() }}
+      if: steps.dependency-submission.outcome != 'failure'
       run: |
-        echo "Previous step didn't fail"
+        echo "Dependency submission step should fail after setup-gradle"
         exit 1

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -57,6 +57,7 @@ jobs:
       with:
         build-root-directory: .github/workflow-samples/groovy-dsl
     - name: Assert step failure
+      if: ${{ success() }}
       run: |
         echo "Previous step didn't fail"
         exit 1

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -43,3 +43,20 @@ jobs:
         build-root-directory: .github/workflow-samples/no-wrapper${{ matrix.build-root-suffix }}
       env:
         GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
+
+  test-after-setup-gradle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Setup Gradle
+      uses: ./setup-gradle
+    - name: Generate and submit dependencies
+      uses: ./dependency-submission
+      continue-on-error: true
+      with:
+        build-root-directory: .github/workflow-samples/groovy-dsl
+    - name: Assert step failure
+      run: |
+        echo "Previous step didn't fail"
+        exit 1

--- a/dependency-submission/action.yml
+++ b/dependency-submission/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Check no setup-gradle
       shell: bash
       run: |
-        if [ -n "${GRADLE_BUILD_ACTION_SETUP_COMPLETED}" ];
+        if [ -n "${GRADLE_BUILD_ACTION_SETUP_COMPLETED}" ]; then
           echo "The dependency-submission action cannot be used in the same Job as the setup-gradle action. Please use a separate Job for dependency submission."
           exit 1
         fi

--- a/dependency-submission/action.yml
+++ b/dependency-submission/action.yml
@@ -53,6 +53,7 @@ runs:
     - name: Check no setup-gradle
       shell: bash
       run: |
+        echo "Test: ${GRADLE_BUILD_ACTION_SETUP_COMPLETED}"
         if [ -n "${GRADLE_BUILD_ACTION_SETUP_COMPLETED}" ]; then
           echo "The dependency-submission action cannot be used in the same Job as the setup-gradle action. Please use a separate Job for dependency submission."
           exit 1

--- a/dependency-submission/action.yml
+++ b/dependency-submission/action.yml
@@ -53,7 +53,6 @@ runs:
     - name: Check no setup-gradle
       shell: bash
       run: |
-        echo "Test: ${GRADLE_BUILD_ACTION_SETUP_COMPLETED}"
         if [ -n "${GRADLE_BUILD_ACTION_SETUP_COMPLETED}" ]; then
           echo "The dependency-submission action cannot be used in the same Job as the setup-gradle action. Please use a separate Job for dependency submission."
           exit 1

--- a/dependency-submission/action.yml
+++ b/dependency-submission/action.yml
@@ -50,6 +50,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check no setup-gradle
+      shell: bash
+      run: |
+        if [ -n "${GRADLE_BUILD_ACTION_SETUP_COMPLETED}" ];
+          echo "The dependency-submission action cannot be used in the same Job as the setup-gradle action. Please use a separate Job for dependency submission."
+          exit 1
+        fi
     - name: Generate dependency graph
       if: ${{ inputs.dependency-graph == 'generate-and-submit' || inputs.dependency-graph == 'generate-and-upload' }}
       uses: gradle/actions/setup-gradle@v3.0.0


### PR DESCRIPTION
Previously, this would fail with a hard-to-diagnose error message.

Fixes #14 