### PR TITLE
Add an ability to capture task input files

### DIFF
--- a/setup-gradle/README.md
+++ b/setup-gradle/README.md
@@ -663,15 +663,16 @@ with a valid [Develocity access key](https://docs.gradle.com/enterprise/gradle-p
 
 The `init-script` supports several additional configuration parameters that you may find useful. All configuration options (required and optional) are detailed below:
 
-| Variable                          | Required | Description |
-|-----------------------------------| --- | --- |
-| DEVELOCITY_INJECTION_ENABLED      | :white_check_mark: | enables Develocity injection |
-| DEVELOCITY_URL                    | :white_check_mark: | the URL of the Develocity server |
-| DEVELOCITY_ALLOW_UNTRUSTED_SERVER | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate |
-| DEVELOCITY_ENFORCE_URL            | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
-| DEVELOCITY_PLUGIN_VERSION         | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply |
-| DEVELOCITY_CCUD_PLUGIN_VERSION    |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any |
-| GRADLE_PLUGIN_REPOSITORY_URL      |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default |
+| Variable                                       | Required | Description                                                                                                                                                              |
+|------------------------------------------------| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DEVELOCITY_INJECTION_ENABLED                   | :white_check_mark: | enables Develocity injection                                                                                                                                             |
+| DEVELOCITY_URL                                 | :white_check_mark: | the URL of the Develocity server                                                                                                                                         |
+| DEVELOCITY_ALLOW_UNTRUSTED_SERVER              | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate                                               |
+| DEVELOCITY_BUILD_SCAN_CAPTURE_TASK_INPUT_FILES | | enables capturing the paths and content hashes of each individual input file                                                                                             |
+| DEVELOCITY_ENFORCE_URL                         | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
+| DEVELOCITY_PLUGIN_VERSION                      | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply                                                                |
+| DEVELOCITY_CCUD_PLUGIN_VERSION                 |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any                             |
+| GRADLE_PLUGIN_REPOSITORY_URL                   |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                                             |
 
 ## Publishing to scans.gradle.com
 

--- a/setup-gradle/README.md
+++ b/setup-gradle/README.md
@@ -663,18 +663,18 @@ with a valid [Develocity access key](https://docs.gradle.com/enterprise/gradle-p
 
 The `init-script` supports several additional configuration parameters that you may find useful. All configuration options (required and optional) are detailed below:
 
-| Variable                            | Required | Description                                                                                                                                                             |
-|-------------------------------------| --- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DEVELOCITY_INJECTION_ENABLED        | :white_check_mark: | enables Develocity injection                                                                                                                                            |
-| DEVELOCITY_URL                      | :white_check_mark: | the URL of the Develocity server                                                                                                                                        |
-| DEVELOCITY_ALLOW_UNTRUSTED_SERVER   | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate                                              |
-| DEVELOCITY_CAPTURE_TASK_INPUT_FILES | | enables capturing the paths and content hashes of each individual input file                                                                                            |
-| DEVELOCITY_ENFORCE_URL              | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
-| DEVELOCITY_PLUGIN_VERSION           | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply                                                               |
-| DEVELOCITY_CCUD_PLUGIN_VERSION      |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any                            |
-| GRADLE_PLUGIN_REPOSITORY_URL        |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                                            |
-| GRADLE_PLUGIN_REPOSITORY_USERNAME   |  | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                                               |
-| GRADLE_PLUGIN_REPOSITORY_PASSWORD   |  | the password for the repository URL to use when resolving the Develocity and CCUD plugins; Consider using secrets to pass the value to this variable                    |
+| Variable                             | Required | Description                                                                                                                                                             |
+|--------------------------------------| --- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DEVELOCITY_INJECTION_ENABLED         | :white_check_mark: | enables Develocity injection                                                                                                                                            |
+| DEVELOCITY_URL                       | :white_check_mark: | the URL of the Develocity server                                                                                                                                        |
+| DEVELOCITY_ALLOW_UNTRUSTED_SERVER    | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate                                              |
+| DEVELOCITY_CAPTURE_FILE_FINGERPRINTS | | enables capturing the paths and content hashes of each individual input file                                                                                            |
+| DEVELOCITY_ENFORCE_URL               | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
+| DEVELOCITY_PLUGIN_VERSION            | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply                                                               |
+| DEVELOCITY_CCUD_PLUGIN_VERSION       |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any                            |
+| GRADLE_PLUGIN_REPOSITORY_URL         |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                                            |
+| GRADLE_PLUGIN_REPOSITORY_USERNAME    |  | the username for the repository URL to use when resolving the Develocity and CCUD plugins                                                                               |
+| GRADLE_PLUGIN_REPOSITORY_PASSWORD    |  | the password for the repository URL to use when resolving the Develocity and CCUD plugins; Consider using secrets to pass the value to this variable                    |
 
 ## Publishing to scans.gradle.com
 

--- a/setup-gradle/README.md
+++ b/setup-gradle/README.md
@@ -663,16 +663,16 @@ with a valid [Develocity access key](https://docs.gradle.com/enterprise/gradle-p
 
 The `init-script` supports several additional configuration parameters that you may find useful. All configuration options (required and optional) are detailed below:
 
-| Variable                                       | Required | Description                                                                                                                                                              |
-|------------------------------------------------| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DEVELOCITY_INJECTION_ENABLED                   | :white_check_mark: | enables Develocity injection                                                                                                                                             |
-| DEVELOCITY_URL                                 | :white_check_mark: | the URL of the Develocity server                                                                                                                                         |
-| DEVELOCITY_ALLOW_UNTRUSTED_SERVER              | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate                                               |
-| DEVELOCITY_BUILD_SCAN_CAPTURE_TASK_INPUT_FILES | | enables capturing the paths and content hashes of each individual input file                                                                                             |
-| DEVELOCITY_ENFORCE_URL                         | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
-| DEVELOCITY_PLUGIN_VERSION                      | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply                                                                |
-| DEVELOCITY_CCUD_PLUGIN_VERSION                 |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any                             |
-| GRADLE_PLUGIN_REPOSITORY_URL                   |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                                             |
+| Variable                            | Required | Description                                                                                                                                                              |
+|-------------------------------------| --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DEVELOCITY_INJECTION_ENABLED        | :white_check_mark: | enables Develocity injection                                                                                                                                             |
+| DEVELOCITY_URL                      | :white_check_mark: | the URL of the Develocity server                                                                                                                                         |
+| DEVELOCITY_ALLOW_UNTRUSTED_SERVER   | | allow communication with an untrusted server; set to _true_ if your Develocity instance is using a self-signed certificate                                               |
+| DEVELOCITY_CAPTURE_TASK_INPUT_FILES | | enables capturing the paths and content hashes of each individual input file                                                                                             |
+| DEVELOCITY_ENFORCE_URL              | | enforce the configured Develocity URL over a URL configured in the project's build; set to _true_ to enforce publication of build scans to the configured Develocity URL |
+| DEVELOCITY_PLUGIN_VERSION           | :white_check_mark: | the version of the [Develocity Gradle plugin](https://docs.gradle.com/enterprise/gradle-plugin/) to apply                                                                |
+| DEVELOCITY_CCUD_PLUGIN_VERSION      |  | the version of the [Common Custom User Data Gradle plugin](https://github.com/gradle/common-custom-user-data-gradle-plugin) to apply, if any                             |
+| GRADLE_PLUGIN_REPOSITORY_URL        |  | the URL of the repository to use when resolving the Develocity and CCUD plugins; the Gradle Plugin Portal is used by default                                             |
 
 ## Publishing to scans.gradle.com
 

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -80,7 +80,7 @@ def geUrl = getInputParam('develocity.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
 def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def geCaptureTaskInputFiles = Boolean.parseBoolean(getInputParam('develocity.build-scan.capture-task-input-files'))
+def geCaptureTaskInputFiles = Boolean.parseBoolean(getInputParam('develocity.capture-task-input-files'))
 def gePluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
@@ -113,11 +113,11 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('5.0')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() >= GradleVersion.version('5.0')) {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
@@ -130,11 +130,11 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('5.0')) {
-                                if (isNotAtLeast(gePluginVersion, '3.7')) {
-                                    buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                                } else {
+                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() >= GradleVersion.version('5.0')) {
+                                if (isAtLeast(gePluginVersion, '3.7')) {
                                     buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                                } else {
+                                    buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                                 }
                             }
                         }
@@ -173,10 +173,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
                     if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
@@ -189,10 +189,10 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isNotAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                        } else {
+                        if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         }
                     }
                 }
@@ -240,5 +240,5 @@ static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
 }
 
 static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
-    GradleVersion.version(versionUnderTest) > GradleVersion.version(referenceVersion)
+    GradleVersion.version(versionUnderTest) >= GradleVersion.version(referenceVersion)
 }

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -113,7 +113,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('4.0')) {
+                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('5.0')) {
                         if (isNotAtLeast(gePluginVersion, '3.7')) {
                             buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         } else {
@@ -130,7 +130,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('4.0')) {
+                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('5.0')) {
                                 if (isNotAtLeast(gePluginVersion, '3.7')) {
                                     buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                                 } else {

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -113,7 +113,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1')) {
+                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('4.0')) {
                         if (isNotAtLeast(gePluginVersion, '3.7')) {
                             buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                         } else {
@@ -130,7 +130,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1')) {
+                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() > GradleVersion.version('4.0')) {
                                 if (isNotAtLeast(gePluginVersion, '3.7')) {
                                     buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
                                 } else {

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -86,6 +86,7 @@ def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
 def buildScanTermsOfServiceAgree = getInputParam('build-scan.terms-of-service.agree')
 
+def atLeastGradle5 = GradleVersion.current() >= GradleVersion.version('5.0')
 def atLeastGradle4 = GradleVersion.current() >= GradleVersion.version('4.0')
 
 // finish early if configuration parameters passed in via system properties are not valid/supported
@@ -113,7 +114,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() >= GradleVersion.version('5.0')) {
+                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                         } else {
@@ -130,7 +131,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                             logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1') && GradleVersion.current() >= GradleVersion.version('5.0')) {
+                            if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                                 if (isAtLeast(gePluginVersion, '3.7')) {
                                     buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
                                 } else {

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -94,7 +94,7 @@ def geUrl = getInputParam('develocity.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
 def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def geCaptureTaskInputFiles = Boolean.parseBoolean(getInputParam('develocity.capture-task-input-files'))
+def geCaptureFileFingerprints = Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints'))
 def gePluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
@@ -123,16 +123,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
                         buildScan.server = geUrl
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
                     if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                            buildScan.capture.taskInputFiles = geCaptureFileFingerprints
                         } else {
-                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                            buildScan.captureTaskInputFiles = geCaptureFileFingerprints
                         }
                     }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
@@ -142,15 +142,15 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                            if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                                if (isAtLeast(gePluginVersion, '3.7')) {
-                                    buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
-                                } else {
-                                    buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
-                                }
+                        }
+                        if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                            if (isAtLeast(gePluginVersion, '3.7')) {
+                                buildScan.capture.taskInputFiles = geCaptureFileFingerprints
+                            } else {
+                                buildScan.captureTaskInputFiles = geCaptureFileFingerprints
                             }
                         }
                     }
@@ -181,7 +181,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
                         ext.server = geUrl
                         ext.allowUntrustedServer = geAllowUntrustedServer
                     }
@@ -189,9 +189,9 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
                     if (isAtLeast(gePluginVersion, '2.1')) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                            ext.buildScan.capture.taskInputFiles = geCaptureFileFingerprints
                         } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                            ext.buildScan.captureTaskInputFiles = geCaptureFileFingerprints
                         }
                     }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
@@ -200,14 +200,14 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geEnforceUrl) {
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
+                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     if (isAtLeast(gePluginVersion, '2.1')) {
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                            ext.buildScan.capture.taskInputFiles = geCaptureFileFingerprints
                         } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                            ext.buildScan.captureTaskInputFiles = geCaptureFileFingerprints
                         }
                     }
                 }

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -80,6 +80,7 @@ def geUrl = getInputParam('develocity.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
 def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
+def geCaptureTaskInputFiles = Boolean.parseBoolean(getInputParam('develocity.build-scan.capture-task-input-files'))
 def gePluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
@@ -107,11 +108,18 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.quiet("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     if (geUrl) {
-                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                         buildScan.server = geUrl
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
+                    if (isAtLeast(gePluginVersion, '2.1')) {
+                        if (isNotAtLeast(gePluginVersion, '3.7')) {
+                            buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        }
+                    }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
@@ -119,9 +127,16 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                            logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
+                            if (isAtLeast(gePluginVersion, '2.1')) {
+                                if (isNotAtLeast(gePluginVersion, '3.7')) {
+                                    buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                                } else {
+                                    buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                                }
+                            }
                         }
                     }
                 }
@@ -151,21 +166,35 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
                     if (geUrl) {
-                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                        logger.quiet("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                         ext.server = geUrl
                         ext.allowUntrustedServer = geAllowUntrustedServer
                     }
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
+                    if (isAtLeast(gePluginVersion, '2.1')) {
+                        if (isNotAtLeast(gePluginVersion, '3.7')) {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        }
+                    }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                 }
             }
 
             if (geUrl && geEnforceUrl) {
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
+                    logger.quiet("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureTaskInputFiles")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
+                    if (isAtLeast(gePluginVersion, '2.1')) {
+                        if (isNotAtLeast(gePluginVersion, '3.7')) {
+                            ext.buildScan.captureTaskInputFiles = geCaptureTaskInputFiles
+                        } else {
+                            ext.buildScan.capture.taskInputFiles = geCaptureTaskInputFiles
+                        }
+                    }
                 }
             }
 
@@ -207,5 +236,9 @@ static def eachDevelocityExtension(def settings, def publicType, def action) {
 }
 
 static boolean isNotAtLeast(String versionUnderTest, String referenceVersion) {
-    GradleVersion.version(versionUnderTest) < GradleVersion.version(referenceVersion)
+    !isAtLeast(versionUnderTest, referenceVersion)
+}
+
+static boolean isAtLeast(String versionUnderTest, String referenceVersion) {
+    GradleVersion.version(versionUnderTest) > GradleVersion.version(referenceVersion)
 }

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -123,7 +123,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
                         buildScan.server = geUrl
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
@@ -142,7 +142,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
+                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
@@ -181,7 +181,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
                         ext.server = geUrl
                         ext.allowUntrustedServer = geAllowUntrustedServer
                     }
@@ -200,7 +200,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geEnforceUrl) {
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
+                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     if (isAtLeast(gePluginVersion, '2.1')) {

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -123,7 +123,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
                         buildScan.server = geUrl
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
@@ -142,7 +142,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
+                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
                         }
@@ -181,7 +181,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
                         ext.server = geUrl
                         ext.allowUntrustedServer = geAllowUntrustedServer
                     }
@@ -200,7 +200,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geEnforceUrl) {
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $geCaptureFileFingerprints")
+                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
                     if (isAtLeast(gePluginVersion, '2.1')) {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -344,8 +344,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert !result.output.contains(pluginApplicationLogMsg)
     }
 
-    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean captureFileFingerprints = false) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $captureFileFingerprints"
+    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean geCaptureFileFingerprints = false) {
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
     }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -214,7 +214,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         then:
         outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
-        outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
+        outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true, true)
         outputMissesCcudPluginApplicationViaInitScript(result)
 
         and:

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -403,7 +403,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (enforceUrl) envVars.put("DEVELOCITY_ENFORCE_URL", "true")
             if (ccudPluginVersion != null) envVars.put("DEVELOCITY_CCUD_PLUGIN_VERSION", ccudPluginVersion)
             if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
-            if (captureTaskInputFiles) envVars.put("DEVELOCITY_BUILD_SCAN_CAPTURE_TASK_INPUT_FILES", "true")
+            if (captureTaskInputFiles) envVars.put("DEVELOCITY_CAPTURE_TASK_INPUT_FILES", "true")
 
             return envVars
         }
@@ -420,7 +420,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (enforceUrl) jvmArgs.add("-Ddevelocity.enforce-url=true")
             if (ccudPluginVersion != null) jvmArgs.add("-Ddevelocity.ccud-plugin.version=$ccudPluginVersion")
             if (pluginRepositoryUrl != null) jvmArgs.add("-Dgradle.plugin-repository.url=$pluginRepositoryUrl")
-            if (captureTaskInputFiles) jvmArgs.add("-Ddevelocity.build-scan.capture-task-input-files=true")
+            if (captureTaskInputFiles) jvmArgs.add("-Ddevelocity.capture-task-input-files=true")
 
             return jvmArgs.collect { it.toString() } // Convert from GStrings
         }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -344,8 +344,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert !result.output.contains(pluginApplicationLogMsg)
     }
 
-    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean captureTaskInputFiles = false) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureTaskInputFiles: $captureTaskInputFiles"
+    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean captureFileFingerprints = false) {
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $captureFileFingerprints"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
     }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -225,11 +225,11 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         testGradleVersion << ALL_VERSIONS
     }
 
-    def "can configure capturing task input files when Develocity plugin is applied by the init script"() {
+    def "can configure capturing file fingerprints when Develocity plugin is applied by the init script"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
-        def config = testConfig().withCaptureTaskInputFiles()
+        def config = testConfig().withCaptureFileFingerprints()
         def result = run(testGradleVersion, config)
 
         then:
@@ -397,7 +397,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         String pluginRepositoryUrl = null
         String pluginRepositoryUsername = null
         String pluginRepositoryPassword = null
-        boolean captureTaskInputFiles = false
+        boolean captureFileFingerprints = false
 
         TestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
             ccudPluginVersion = version
@@ -415,8 +415,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             return this
         }
 
-        TestConfig withCaptureTaskInputFiles() {
-            this.captureTaskInputFiles = true
+        TestConfig withCaptureFileFingerprints() {
+            this.captureFileFingerprints = true
             return this
         }
 
@@ -439,7 +439,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
             if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
             if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
-            if (captureTaskInputFiles) envVars.put("DEVELOCITY_CAPTURE_TASK_INPUT_FILES", "true")
+            if (captureFileFingerprints) envVars.put("DEVELOCITY_CAPTURE_FILE_FINGERPRINTS", "true")
 
             return envVars
         }
@@ -458,7 +458,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (pluginRepositoryUrl != null) jvmArgs.add("-Dgradle.plugin-repository.url=$pluginRepositoryUrl")
             if (pluginRepositoryUsername != null) jvmArgs.add("-Dgradle.plugin-repository.username=$pluginRepositoryUsername")
             if (pluginRepositoryPassword != null) jvmArgs.add("-Dgradle.plugin-repository.password=$pluginRepositoryPassword")
-            if (captureTaskInputFiles) jvmArgs.add("-Ddevelocity.capture-task-input-files=true")
+            if (captureFileFingerprints) jvmArgs.add("-Ddevelocity.capture-file-fingerprints=true")
 
             return jvmArgs.collect { it.toString() } // Convert from GStrings
         }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -345,7 +345,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     }
 
     void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean geCaptureFileFingerprints = false) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints"
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
     }

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -395,8 +395,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         boolean enforceUrl = false
         String ccudPluginVersion = null
         String pluginRepositoryUrl = null
-        String pluginRepoUsername = null
-        String pluginRepoPassword = null
+        String pluginRepositoryUsername = null
+        String pluginRepositoryPassword = null
         boolean captureTaskInputFiles = false
 
         TestConfig withCCUDPlugin(String version = CCUD_PLUGIN_VERSION) {
@@ -421,8 +421,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         }
 
         TestConfig withPluginRepositoryCredentials(String pluginRepoUsername, String pluginRepoPassword) {
-            this.pluginRepoUsername = pluginRepoUsername
-            this.pluginRepoPassword = pluginRepoPassword
+            this.pluginRepositoryUsername = pluginRepoUsername
+            this.pluginRepositoryPassword = pluginRepoPassword
             return this
         }
 
@@ -437,8 +437,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (enforceUrl) envVars.put("DEVELOCITY_ENFORCE_URL", "true")
             if (ccudPluginVersion != null) envVars.put("DEVELOCITY_CCUD_PLUGIN_VERSION", ccudPluginVersion)
             if (pluginRepositoryUrl != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_URL", pluginRepositoryUrl)
-            if (pluginRepoUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepoUsername)
-            if (pluginRepoPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepoPassword)
+            if (pluginRepositoryUsername != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_USERNAME", pluginRepositoryUsername)
+            if (pluginRepositoryPassword != null) envVars.put("GRADLE_PLUGIN_REPOSITORY_PASSWORD", pluginRepositoryPassword)
             if (captureTaskInputFiles) envVars.put("DEVELOCITY_CAPTURE_TASK_INPUT_FILES", "true")
 
             return envVars
@@ -456,8 +456,8 @@ class TestDevelocityInjection extends BaseInitScriptTest {
             if (enforceUrl) jvmArgs.add("-Ddevelocity.enforce-url=true")
             if (ccudPluginVersion != null) jvmArgs.add("-Ddevelocity.ccud-plugin.version=$ccudPluginVersion")
             if (pluginRepositoryUrl != null) jvmArgs.add("-Dgradle.plugin-repository.url=$pluginRepositoryUrl")
-            if (pluginRepoUsername != null) jvmArgs.add("-Dgradle.plugin-repository.username=$pluginRepoUsername")
-            if (pluginRepoPassword != null) jvmArgs.add("-Dgradle.plugin-repository.password=$pluginRepoPassword")
+            if (pluginRepositoryUsername != null) jvmArgs.add("-Dgradle.plugin-repository.username=$pluginRepositoryUsername")
+            if (pluginRepositoryPassword != null) jvmArgs.add("-Dgradle.plugin-repository.password=$pluginRepositoryPassword")
             if (captureTaskInputFiles) jvmArgs.add("-Ddevelocity.capture-task-input-files=true")
 
             return jvmArgs.collect { it.toString() } // Convert from GStrings

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -345,7 +345,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     }
 
     void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean geCaptureFileFingerprints = false) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints"
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, geCaptureFileFingerprints: $geCaptureFileFingerprints"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
     }


### PR DESCRIPTION
This PR adds an ability to enable/disable [capturing task input files](https://docs.gradle.com/enterprise/gradle-plugin/#capturing_task_input_files) in a build scan.