### PR TITLE
Capture task input files when plugin not applied

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -94,7 +94,7 @@ def geUrl = getInputParam('develocity.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
 def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def geCaptureFileFingerprints = Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints'))
+def geCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints')
 def gePluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
@@ -123,35 +123,29 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     logger.lifecycle("Applying $BUILD_SCAN_PLUGIN_CLASS via init script")
                     applyPluginExternally(pluginManager, BUILD_SCAN_PLUGIN_CLASS)
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                         buildScan.server = geUrl
                         buildScan.allowUntrustedServer = geAllowUntrustedServer
                     }
                     buildScan.publishAlways()
-                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                        if (isAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.capture.taskInputFiles = geCaptureFileFingerprints
-                        } else {
-                            buildScan.captureTaskInputFiles = geCaptureFileFingerprints
-                        }
-                    }
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
+                    if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        if (isAtLeast(gePluginVersion, '3.7')) {
+                            buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                        } else {
+                            buildScan.captureTaskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                        }
+                    }
                 }
 
                 if (geUrl && geEnforceUrl) {
                     pluginManager.withPlugin(BUILD_SCAN_PLUGIN_ID) {
                         afterEvaluate {
-                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
+                            logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                             buildScan.server = geUrl
                             buildScan.allowUntrustedServer = geAllowUntrustedServer
-                        }
-                        if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                            if (isAtLeast(gePluginVersion, '3.7')) {
-                                buildScan.capture.taskInputFiles = geCaptureFileFingerprints
-                            } else {
-                                buildScan.captureTaskInputFiles = geCaptureFileFingerprints
-                            }
                         }
                     }
                 }
@@ -181,17 +175,18 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                 applyPluginExternally(settings.pluginManager, DEVELOCITY_PLUGIN_CLASS)
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
                     if (geUrl) {
-                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
+                        logger.lifecycle("Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                         ext.server = geUrl
                         ext.allowUntrustedServer = geAllowUntrustedServer
                     }
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                    if (isAtLeast(gePluginVersion, '2.1')) {
+                    if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1')) {
+                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureFileFingerprints
+                            ext.buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
                         } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureFileFingerprints
+                            ext.buildScan.captureTaskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
                         }
                     }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
@@ -200,16 +195,9 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
 
             if (geUrl && geEnforceUrl) {
                 eachDevelocityExtension(settings, DEVELOCITY_EXTENSION_CLASS) { ext ->
-                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints")
+                    logger.lifecycle("Enforcing Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer")
                     ext.server = geUrl
                     ext.allowUntrustedServer = geAllowUntrustedServer
-                    if (isAtLeast(gePluginVersion, '2.1')) {
-                        if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = geCaptureFileFingerprints
-                        } else {
-                            ext.buildScan.captureTaskInputFiles = geCaptureFileFingerprints
-                        }
-                    }
                 }
             }
 

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -94,7 +94,7 @@ def geUrl = getInputParam('develocity.url')
 def geAllowUntrustedServer = Boolean.parseBoolean(getInputParam('develocity.allow-untrusted-server'))
 def geEnforceUrl = Boolean.parseBoolean(getInputParam('develocity.enforce-url'))
 def buildScanUploadInBackground = Boolean.parseBoolean(getInputParam('develocity.build-scan.upload-in-background'))
-def geCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints')
+def develocityCaptureFileFingerprints = getInputParam('develocity.capture-file-fingerprints') ? Boolean.parseBoolean(getInputParam('develocity.capture-file-fingerprints')) : true
 def gePluginVersion = getInputParam('develocity.plugin.version')
 def ccudPluginVersion = getInputParam('develocity.ccud-plugin.version')
 def buildScanTermsOfServiceUrl = getInputParam('build-scan.terms-of-service.url')
@@ -130,12 +130,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     buildScan.publishAlways()
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
-                    if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                        logger.lifecycle("Setting captureFileFingerprints: $geCaptureFileFingerprints")
+                    if (isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
+                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                            buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
                         } else {
-                            buildScan.captureTaskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                            buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
                         }
                     }
                 }
@@ -181,12 +181,12 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     }
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
-                    if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1')) {
-                        logger.lifecycle("Setting captureFileFingerprints: $geCaptureFileFingerprints")
+                    if (isAtLeast(gePluginVersion, '2.1')) {
+                        logger.lifecycle("Setting captureFileFingerprints: $develocityCaptureFileFingerprints")
                         if (isAtLeast(gePluginVersion, '3.7')) {
-                            ext.buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                            ext.buildScan.capture.taskInputFiles = develocityCaptureFileFingerprints
                         } else {
-                            ext.buildScan.captureTaskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
+                            ext.buildScan.captureTaskInputFiles = develocityCaptureFileFingerprints
                         }
                     }
                     ext.buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -131,7 +131,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     if (buildScan.metaClass.respondsTo(buildScan, 'setUploadInBackground', Boolean)) buildScan.uploadInBackground = buildScanUploadInBackground  // uploadInBackground not available for build-scan-plugin 1.16
                     buildScan.value CI_AUTO_INJECTION_CUSTOM_VALUE_NAME, CI_AUTO_INJECTION_CUSTOM_VALUE_VALUE
                     if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1') && atLeastGradle5) {
-                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        logger.lifecycle("Setting captureFileFingerprints: $geCaptureFileFingerprints")
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
                         } else {
@@ -182,7 +182,7 @@ if (GradleVersion.current() < GradleVersion.version('6.0')) {
                     ext.buildScan.publishAlways()
                     ext.buildScan.uploadInBackground = buildScanUploadInBackground
                     if (geCaptureFileFingerprints && isAtLeast(gePluginVersion, '2.1')) {
-                        logger.lifecycle("Setting captureTaskInputFiles: $geCaptureTaskInputFiles")
+                        logger.lifecycle("Setting captureFileFingerprints: $geCaptureFileFingerprints")
                         if (isAtLeast(gePluginVersion, '3.7')) {
                             ext.buildScan.capture.taskInputFiles = Boolean.parseBoolean(geCaptureFileFingerprints)
                         } else {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -236,6 +236,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true, true)
         outputMissesCcudPluginApplicationViaInitScript(result)
+        outputCaptureFileFingerprints(result, true)
 
         and:
         outputContainsBuildScanUrl(result)
@@ -344,10 +345,16 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         assert !result.output.contains(pluginApplicationLogMsg)
     }
 
-    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer, boolean geCaptureFileFingerprints = false) {
-        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer, captureFileFingerprints: $geCaptureFileFingerprints"
+    void outputContainsDevelocityConnectionInfo(BuildResult result, String geUrl, boolean geAllowUntrustedServer) {
+        def geConnectionInfo = "Connection to Develocity: $geUrl, allowUntrustedServer: $geAllowUntrustedServer"
         assert result.output.contains(geConnectionInfo)
         assert 1 == result.output.count(geConnectionInfo)
+    }
+
+    void outputCaptureFileFingerprints(BuildResult result, boolean captureFileFingerprints) {
+        def captureFileFingerprintsInfo = "Setting captureFileFingerprints: $captureFileFingerprints"
+        assert result.output.contains(captureFileFingerprintsInfo)
+        assert 1 == result.output.count(captureFileFingerprintsInfo)
     }
 
     void outputContainsPluginRepositoryInfo(BuildResult result, String gradlePluginRepositoryUrl, boolean withCredentials = false) {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -236,7 +236,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
-        if (testGradleVersion.gradleVersion > GRADLE_5_X) {
+        if (testGradleVersion.gradleVersion >= GRADLE_5_X.gradleVersion) {
             outputCaptureFileFingerprints(result, true)
         }
 

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -236,7 +236,9 @@ class TestDevelocityInjection extends BaseInitScriptTest {
         outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
         outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
-        outputCaptureFileFingerprints(result, true)
+        if (testGradleVersion.gradleVersion > GRADLE_5_X) {
+            outputCaptureFileFingerprints(result, true)
+        }
 
         and:
         outputContainsBuildScanUrl(result)

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -234,7 +234,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
 
         then:
         outputContainsDevelocityPluginApplicationViaInitScript(result, testGradleVersion.gradleVersion)
-        outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true, true)
+        outputContainsDevelocityConnectionInfo(result, mockScansServer.address.toString(), true)
         outputMissesCcudPluginApplicationViaInitScript(result)
         outputCaptureFileFingerprints(result, true)
 


### PR DESCRIPTION
This PR changes the behavior such that task input files are captured when the environment variable is explicitly specified and for the cases when the plugin is not applied.