### PR TITLE
Truncate long values in job summary table

### DIFF
--- a/.github/workflows/demo-job-summary.yml
+++ b/.github/workflows/demo-job-summary.yml
@@ -35,6 +35,7 @@ jobs:
       run: | 
          ./gradlew tasks --no-daemon
          ./gradlew help check
+         ./gradlew wrapper --gradle-version 8.7 --gradle-distribution-sha256-sum 544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
     - name: Fail groovy-dsl project
       working-directory: .github/workflow-samples/groovy-dsl
       continue-on-error: true

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -96,8 +96,8 @@ function renderSummaryTable(results: BuildResult[]): string {
 function renderBuildResultRow(result: BuildResult): string {
     return `
     <tr>
-        <td>${result.rootProjectName}</td>
-        <td>${result.requestedTasks}</td>
+        <td>${truncateString(result.rootProjectName, 30)}</td>
+        <td>${truncateString(result.requestedTasks, 60)}</td>
         <td align='center'>${result.gradleVersion}</td>
         <td align='center'>${renderOutcome(result)}</td>
         <td>${renderBuildScan(result)}</td>
@@ -155,5 +155,13 @@ function shouldAddJobSummary(option: params.JobSummaryOption, buildResults: Buil
         case params.JobSummaryOption.OnFailure:
             core.info(`Got these build results: ${JSON.stringify(buildResults)}`)
             return buildResults.some(result => result.buildFailed)
+    }
+}
+
+function truncateString(str: string, maxLength: number): string {
+    if (str.length > maxLength) {
+        return `${str.slice(0, maxLength - 1)}…`
+    } else {
+        return str
     }
 }


### PR DESCRIPTION
Based on https://github.com/gradle/gradle-build-action/commit/1c1a43bc26346549ec6d7729f1e31a486826d29c, the only meaningful change is the use of ellipsis chararcter instead of triple dots.
Fix #35