### PR TITLE
Include PR triggers in workflows

### DIFF
--- a/.github/workflows/ci-check-and-unit-test.yml
+++ b/.github/workflows/ci-check-and-unit-test.yml
@@ -2,6 +2,10 @@ name: CI-check-and-unit-test
 
 on:
   push:
+    branches:
+    - 'main'
+    - 'release/**'
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-check-no-dist-update.yml
+++ b/.github/workflows/ci-check-no-dist-update.yml
@@ -3,10 +3,7 @@ name: CI-check-no-dist-update
 # Prohibit any change to 'dist/**' on a non-release branch
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release/**'
+  pull_request:
     paths:
       - 'dist/**'
 

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -3,8 +3,6 @@ name: CI-codeql
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '25 23 * * 2'
 

--- a/.github/workflows/ci-init-script-check.yml
+++ b/.github/workflows/ci-init-script-check.yml
@@ -2,6 +2,10 @@ name: CI-init-script-check
 
 on:
   push:
+    branches:
+    - 'main'
+    - 'release/**'
+  pull_request:
     paths:
       - '.github/workflows/ci-init-script-check.yml'
       - 'sources/src/resources/init-scripts/**'

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -7,6 +7,7 @@ on:
     branches:
     - 'main'
     - 'release/**'
+    - 'dev/**' # Allow running quick tests on dev branch for testing
 
 jobs:
   determine-suite:
@@ -33,7 +34,12 @@ jobs:
           exit 0
         fi
 
-        # TODO: Make it easy to experiment with no PR and quick suite
+        # Run quick suite for push trigger on 'dev' branches
+        if [[ "${{ github.ref_name }}" == "dev/"* ]]; then
+          echo "Push to dev branch: suite=quick"
+          echo "suite=quick" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
 
         # Run full suite for everything else
         echo "Everything else: suite=full"

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -2,7 +2,11 @@ name: CI-integ-test
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches:
+    - 'main'
+    - 'release/**'
 
 jobs:
   determine-suite:
@@ -11,9 +15,6 @@ jobs:
       runner-os: ${{ steps.determine-suite.outputs.suite == 'quick' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]' }}
       cache-key-prefix: ${{ steps.determine-suite.outputs.suite == 'quick' && '0' || github.run_number }}
     steps:
-    - name: Get current PR details
-      uses: 8BitJonny/gh-get-current-pr@3.0.0
-      id: PR
     - name: Determine suite to run
       id: determine-suite
       run: |
@@ -32,14 +33,11 @@ jobs:
           exit 0
         fi
 
-        # Run full suite for PRs
-        if [ "${{ steps.PR.outputs.pr_found }}" == "false" ]; then
-          echo "PR not found: suite=quick"
-          echo "suite=quick" >> "$GITHUB_OUTPUT"
-        else
-          echo "PR found: suite=full"
-          echo "suite=full" >> "$GITHUB_OUTPUT"
-        fi
+        # TODO: Make it easy to experiment with no PR and quick suite
+
+        # Run full suite for everything else
+        echo "Everything else: suite=full"
+        echo "suite=full" >> "$GITHUB_OUTPUT"
 
   build-distribution:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-update-dist.yml
+++ b/.github/workflows/ci-update-dist.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: 
-      - 'main'
-      - 'release/**'
+    - 'main'
+    - 'release/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
In order to keep the 'push' triggers for ease of use (and quick tests), we extend the 'determine-suite' logic to include a 'skip' action when the workflow is duplicated.

This logic is extracted into a composite action, and used to avoid duplicate runs of unit-tests, integration tests and init-script tests.