### PR TITLE
Update extracted cache entries for Gradle 8.6+

### DIFF
--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -358,8 +358,10 @@ export class GradleHomeEntryExtractor extends AbstractEntryExtractor {
             entryDefinition('wrapper-zips', ['wrapper/dists/*/*/'], false), // Each wrapper directory cached separately
             entryDefinition('java-toolchains', ['jdks/*/'], false), // Each extracted JDK cached separately
             entryDefinition('dependencies', ['caches/modules-*/files-*/*/*/*/*'], true),
-            entryDefinition('instrumented-jars', ['caches/jars-*/*'], true),
-            entryDefinition('kotlin-dsl', ['caches/*/kotlin-dsl/*/*'], true)
+            entryDefinition('instrumented-jars', ['caches/jars-*/*/'], true),
+            entryDefinition('kotlin-dsl', ['caches/*/kotlin-dsl/accessors/*/', 'caches/*/kotlin-dsl/scripts/*/'], true),
+            entryDefinition('groovy-dsl', ['caches/*/groovy-dsl/*/'], true),
+            entryDefinition('transforms', ['caches/transforms-4/*/', 'caches/*/transforms/*/'], true)
         ]
     }
 }


### PR DESCRIPTION
- Extracted `groovy-dsl` from each version
- Extracted transform jars

Fixes #45