### PR TITLE
Skip the 'download-dist' step for full integ-test

### DIFF
--- a/.github/actions/init-integ-test/action.yml
+++ b/.github/actions/init-integ-test/action.yml
@@ -11,7 +11,7 @@ runs:
 
     # Downloads a 'dist' directory artifact that was uploaded in an earlier 'build-dist' step
     - name: Download dist
-      if: ${{ !env.ACT }}
+      if: ${{ env.SKIP_DIST != 'true' && !env.ACT }}
       uses: actions/download-artifact@v4
       with:
         name: dist

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       runner-os: ${{ steps.determine-suite.outputs.suite == 'quick' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]' }}
-      cache-key-prefix: ${{ steps.determine-suite.outputs.suite == 'quick' && '0' || github.run_number }}
+      cache-key-prefix: '0' # TODO DAZ Try this again ${{ steps.determine-suite.outputs.suite == 'quick' && '0' || github.run_number }}
+      suite: ${{ steps.determine-suite.outputs.suite }}
     steps:
     - name: Determine suite to run
       id: determine-suite
@@ -43,11 +44,13 @@ jobs:
         echo "suite=quick" >> "$GITHUB_OUTPUT"
 
   build-distribution:
+    needs: [determine-suite]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
     - name: Build and upload distribution
+      if: ${{ needs.determine-suite.outputs.suite != 'full' }}
       uses: ./.github/actions/build-dist
 
   action-inputs:
@@ -56,6 +59,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   build-scan-publish:
     needs: [determine-suite, build-distribution]
@@ -63,6 +67,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   cache-cleanup:
     needs: [determine-suite, build-distribution]
@@ -70,6 +75,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{github.run_number}}-' # Requires a fresh cache entry each run
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   caching-config:
     needs: [determine-suite, build-distribution]
@@ -77,6 +83,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-graph:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -87,6 +94,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-submission:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -97,6 +105,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-submission-failures:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -107,6 +116,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   execution-with-caching:
     needs: [determine-suite, build-distribution]
@@ -114,6 +124,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   execution:
     needs: [determine-suite, build-distribution]
@@ -121,6 +132,7 @@ jobs:
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
       cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   develocity-injection:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -128,6 +140,8 @@ jobs:
     uses: ./.github/workflows/integ-test-inject-develocity.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
 
@@ -136,6 +150,8 @@ jobs:
     uses: ./.github/workflows/integ-test-provision-gradle-versions.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-configuration-cache:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
@@ -143,49 +159,68 @@ jobs:
     uses: ./.github/workflows/integ-test-restore-configuration-cache.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   restore-containerized-gradle-home:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-containerized-gradle-home.yml
+    with:
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-custom-gradle-home:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-custom-gradle-home.yml
+    with:
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-gradle-home:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-gradle-home.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-java-toolchain:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-java-toolchain.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   sample-kotlin-dsl:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-sample-kotlin-dsl.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   sample-gradle-plugin:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-sample-gradle-plugin.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   toolchain-detection:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-detect-java-toolchains.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   wrapper-validation:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-wrapper-validation.yml
     with:
       runner-os: '["ubuntu-latest"]'
+      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}

--- a/.github/workflows/integ-test-action-inputs.yml
+++ b/.github/workflows/integ-test-action-inputs.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: action-inputs-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-build-scan-publish.yml
+++ b/.github/workflows/integ-test-build-scan-publish.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: build-scan-publish-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-cache-cleanup.yml
+++ b/.github/workflows/integ-test-cache-cleanup.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: cache-cleanup-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-caching-config.yml
+++ b/.github/workflows/integ-test-caching-config.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: caching-config-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-dependency-graph.yml
+++ b/.github/workflows/integ-test-dependency-graph.yml
@@ -8,11 +8,15 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-graph-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-dependency-submission-failures.yml
+++ b/.github/workflows/integ-test-dependency-submission-failures.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-submission-failures-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-dependency-submission.yml
+++ b/.github/workflows/integ-test-dependency-submission.yml
@@ -8,11 +8,15 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-submission-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-detect-java-toolchains.yml
+++ b/.github/workflows/integ-test-detect-java-toolchains.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: detect-java-toolchain-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-execution-with-caching.yml
+++ b/.github/workflows/integ-test-execution-with-caching.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: execution-with-caching-${{ inputs.cache-key-prefix }}
   GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 

--- a/.github/workflows/integ-test-execution.yml
+++ b/.github/workflows/integ-test-execution.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: execution-${{ inputs.cache-key-prefix }}
 
 jobs:   

--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -8,11 +8,15 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
     secrets:
       DEVELOCITY_ACCESS_KEY:
         required: true
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: inject-develocity-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-provision-gradle-versions.yml
+++ b/.github/workflows/integ-test-provision-gradle-versions.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: provision-gradle-versions-${{ inputs.cache-key-prefix }}
   GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 

--- a/.github/workflows/integ-test-restore-configuration-cache.yml
+++ b/.github/workflows/integ-test-restore-configuration-cache.yml
@@ -8,11 +8,15 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: true
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-configuration-cache-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-restore-containerized-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-containerized-gradle-home.yml
@@ -5,8 +5,12 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-containerized-gradle-home-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-restore-custom-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-custom-gradle-home.yml
@@ -5,8 +5,12 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-custom-gradle-home-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-restore-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-gradle-home.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-gradle-home-${{ inputs.cache-key-prefix }}
   GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-gradle-home
 

--- a/.github/workflows/integ-test-restore-java-toolchain.yml
+++ b/.github/workflows/integ-test-restore-java-toolchain.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-java-toolchain-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-sample-gradle-plugin.yml
+++ b/.github/workflows/integ-test-sample-gradle-plugin.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: sample-gradle-plugin-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-sample-kotlin-dsl.yml
+++ b/.github/workflows/integ-test-sample-kotlin-dsl.yml
@@ -8,8 +8,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
 
 env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: sample-kotlin-dsl-${{ inputs.cache-key-prefix }}
 
 jobs:

--- a/.github/workflows/integ-test-wrapper-validation.yml
+++ b/.github/workflows/integ-test-wrapper-validation.yml
@@ -6,6 +6,12 @@ on:
       runner-os:
         type: string
         default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
+
+env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
 
 jobs:
   test-setup-gradle-validation:


### PR DESCRIPTION
After the '[bot] update dist directory' commit, we run a full test suite. This will now use the content from the 'dist' directory, rather than regenerating this content in the test.