### PR TITLE
Fix bug finding dependency-graph files with 'download-and-submit'

### DIFF
--- a/.github/workflows/integ-test-dependency-graph.yml
+++ b/.github/workflows/integ-test-dependency-graph.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-graph-${{ inputs.cache-key-prefix }}
+  GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
   groovy-generate:

--- a/.github/workflows/integ-test-dependency-submission-failures.yml
+++ b/.github/workflows/integ-test-dependency-submission-failures.yml
@@ -15,6 +15,7 @@ on:
 env:
   SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-submission-failures-${{ inputs.cache-key-prefix }}
+  GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
   failing-build:

--- a/.github/workflows/integ-test-dependency-submission.yml
+++ b/.github/workflows/integ-test-dependency-submission.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   SKIP_DIST: ${{ inputs.skip-dist }}
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: dependency-submission-${{ inputs.cache-key-prefix }}
+  GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
   groovy-generate-and-upload:
@@ -223,8 +224,6 @@ jobs:
       with:
         gradle-version: ${{ matrix.gradle }}
         build-root-directory: .github/workflow-samples/no-wrapper${{ matrix.build-root-suffix }}
-      env:
-        GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
   after-setup-gradle:
     strategy:

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -22,6 +22,7 @@ export async function setup(config: DependencyGraphConfig): Promise<void> {
     }
     // Download and submit early, for compatability with dependency review.
     if (option === DependencyGraphOption.DownloadAndSubmit) {
+        maybeExportVariable('DEPENDENCY_GRAPH_REPORT_DIR', config.getReportDirectory())
         await downloadAndSubmitDependencyGraphs(config)
         return
     }


### PR DESCRIPTION
When 'download-and-submit' was used, the correct `DEPENDENCY_GRAPH_REPORT_DIR` was not set and the action was not able to locate the downloaded files.