### PR TITLE
Improve build scan badge readability with long tasks

### DIFF
--- a/build
+++ b/build
@@ -5,7 +5,7 @@ cd sources
 case "$1" in
     all)
         npm clean-install
-        nprm run all
+        npm run all
         ;;
     act)
         # Build and copy outputs to the dist directory

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -113,7 +113,7 @@ function renderBuildResults(results: BuildResult[]): string {
         <th>Requested Tasks</th>
         <th>Gradle Version</th>
         <th>Build Outcome</th>
-        <th>Build Scan®</th>
+        <th>Build&nbsp;Scan®</th>
     </tr>${results.map(result => renderBuildResultRow(result)).join('')}
 </table>
     `
@@ -134,23 +134,46 @@ function renderOutcome(result: BuildResult): string {
     return result.buildFailed ? ':x:' : ':white_check_mark:'
 }
 
-function renderBuildScan(result: BuildResult): string {
-    if (result.buildScanFailed) {
-        return renderBuildScanBadge(
-            'PUBLISH_FAILED',
-            'orange',
-            'https://docs.gradle.com/develocity/gradle-plugin/#troubleshooting'
-        )
-    }
-    if (result.buildScanUri) {
-        return renderBuildScanBadge('PUBLISHED', '06A0CE', result.buildScanUri)
-    }
-    return renderBuildScanBadge('NOT_PUBLISHED', 'lightgrey', 'https://scans.gradle.com')
+interface BadgeSpec {
+    text: string
+    alt: string
+    color: string
+    logo: boolean
+    targetUrl: string
 }
 
-function renderBuildScanBadge(outcomeText: string, outcomeColor: string, targetUrl: string): string {
-    const badgeUrl = `https://img.shields.io/badge/Build%20Scan%C2%AE-${outcomeText}-${outcomeColor}?logo=Gradle`
-    const badgeHtml = `<img src="${badgeUrl}" alt="Build Scan ${outcomeText}" />`
+function renderBuildScan(result: BuildResult): string {
+    if (result.buildScanFailed) {
+        return renderBuildScanBadge({
+            text: 'Publish failed',
+            alt: 'Build Scan publish failed',
+            color: 'orange',
+            logo: false,
+            targetUrl: 'https://docs.gradle.com/develocity/gradle-plugin/#troubleshooting'
+        })
+    }
+    if (result.buildScanUri) {
+        return renderBuildScanBadge({
+            text: 'Build Scan®',
+            alt: 'Build Scan published',
+            color: '06A0CE',
+            logo: true,
+            targetUrl: result.buildScanUri
+        })
+    }
+    return renderBuildScanBadge({
+        text: 'Not published',
+        alt: 'Build Scan not published',
+        color: 'lightgrey',
+        logo: false,
+        targetUrl: 'https://scans.gradle.com'
+    })
+}
+
+function renderBuildScanBadge({text, alt, color, logo, targetUrl}: BadgeSpec): string {
+    const encodedText = encodeURIComponent(text)
+    const badgeUrl = `https://img.shields.io/badge/${encodedText}-${color}${logo ? '?logo=Gradle' : ''}`
+    const badgeHtml = `<img src="${badgeUrl}" alt="${alt}" />`
     return `<a href="${targetUrl}" rel="nofollow" target="_blank">${badgeHtml}</a>`
 }
 

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -78,7 +78,7 @@ Note that this permission is never available for a workflow triggered from a rep
     return mainWarning
 }
 
-function renderSummaryTable(results: BuildResult[]): string {
+export function renderSummaryTable(results: BuildResult[]): string {
     return `${renderDeprecations()}\n${renderBuildResults(results)}`
 }
 

--- a/sources/test/jest/job-summary.test.ts
+++ b/sources/test/jest/job-summary.test.ts
@@ -47,14 +47,14 @@ describe('renderSummaryTable', () => {
                         <th>Requested Tasks</th>
                         <th>Gradle Version</th>
                         <th>Build Outcome</th>
-                        <th>Build Scan®</th>
+                        <th>Build&nbsp;Scan®</th>
                     </tr>
                     <tr>
                         <td>root</td>
                         <td>help</td>
                         <td align='center'>8.0</td>
                         <td align='center'>:white_check_mark:</td>
-                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-06A0CE?logo=Gradle" alt="Build Scan published" /></a></td>
                     </tr>
                 </table>
             `);
@@ -68,14 +68,14 @@ describe('renderSummaryTable', () => {
                         <th>Requested Tasks</th>
                         <th>Gradle Version</th>
                         <th>Build Outcome</th>
-                        <th>Build Scan®</th>
+                        <th>Build&nbsp;Scan®</th>
                     </tr>
                     <tr>
                         <td>root</td>
                         <td>help</td>
                         <td align='center'>8.0</td>
                         <td align='center'>:x:</td>
-                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-06A0CE?logo=Gradle" alt="Build Scan published" /></a></td>
                     </tr>
                 </table>
             `);
@@ -90,14 +90,14 @@ describe('renderSummaryTable', () => {
                             <th>Requested Tasks</th>
                             <th>Gradle Version</th>
                             <th>Build Outcome</th>
-                            <th>Build Scan®</th>
+                            <th>Build&nbsp;Scan®</th>
                         </tr>
                         <tr>
                             <td>root</td>
                             <td>help</td>
                             <td align='center'>8.0</td>
                             <td align='center'>:white_check_mark:</td>
-                            <td><a href="https://scans.gradle.com" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-NOT_PUBLISHED-lightgrey?logo=Gradle" alt="Build Scan NOT_PUBLISHED" /></a></td>
+                            <td><a href="https://scans.gradle.com" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Not%20published-lightgrey" alt="Build Scan not published" /></a></td>
                         </tr>
                     </table>
                 `);
@@ -111,14 +111,14 @@ describe('renderSummaryTable', () => {
                             <th>Requested Tasks</th>
                             <th>Gradle Version</th>
                             <th>Build Outcome</th>
-                            <th>Build Scan®</th>
+                            <th>Build&nbsp;Scan®</th>
                         </tr>
                         <tr>
                             <td>root</td>
                             <td>help</td>
                             <td align='center'>8.0</td>
                             <td align='center'>:white_check_mark:</td>
-                            <td><a href="https://docs.gradle.com/develocity/gradle-plugin/#troubleshooting" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISH_FAILED-orange?logo=Gradle" alt="Build Scan PUBLISH_FAILED" /></a></td>
+                            <td><a href="https://docs.gradle.com/develocity/gradle-plugin/#troubleshooting" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Publish%20failed-orange" alt="Build Scan publish failed" /></a></td>
                         </tr>
                     </table>
                 `);
@@ -133,21 +133,21 @@ describe('renderSummaryTable', () => {
                         <th>Requested Tasks</th>
                         <th>Gradle Version</th>
                         <th>Build Outcome</th>
-                        <th>Build Scan®</th>
+                        <th>Build&nbsp;Scan®</th>
                     </tr>
                     <tr>
                         <td>root</td>
                         <td>help</td>
                         <td align='center'>8.0</td>
                         <td align='center'>:white_check_mark:</td>
-                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-06A0CE?logo=Gradle" alt="Build Scan published" /></a></td>
                     </tr>
                     <tr>
                         <td>root</td>
                         <td>help</td>
                         <td align='center'>8.0</td>
                         <td align='center'>:x:</td>
-                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-06A0CE?logo=Gradle" alt="Build Scan published" /></a></td>
                     </tr>
                 </table>
             `);
@@ -161,14 +161,14 @@ describe('renderSummaryTable', () => {
                         <th>Requested Tasks</th>
                         <th>Gradle Version</th>
                         <th>Build Outcome</th>
-                        <th>Build Scan®</th>
+                        <th>Build&nbsp;Scan®</th>
                     </tr>
                     <tr>
                         <td>root</td>
                         <td><div title='check publishMyLongNamePluginPublicationToMavenCentral publishMyLongNamePluginPublicationToPluginPortal'>check publishMyLongNamePluginPublicationToMavenCentral publ…</div></td>
                         <td align='center'>8.0</td>
                         <td align='center'>:white_check_mark:</td>
-                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-06A0CE?logo=Gradle" alt="Build Scan published" /></a></td>
                     </tr>
                 </table>
             `);

--- a/sources/test/jest/job-summary.test.ts
+++ b/sources/test/jest/job-summary.test.ts
@@ -1,0 +1,177 @@
+import { BuildResult } from '../../src/build-results'
+import { renderSummaryTable } from '../../src/job-summary'
+import dedent from 'dedent'
+
+
+const successfulHelpBuild: BuildResult = {
+    rootProjectName: 'root',
+    rootProjectDir: '/',
+    requestedTasks: 'help',
+    gradleVersion: '8.0',
+    gradleHomeDir: '/opt/gradle',
+    buildFailed: false,
+    buildScanUri: 'https://scans.gradle.com/s/abc123',
+    buildScanFailed: false
+}
+
+const failedHelpBuild: BuildResult = {
+    ...successfulHelpBuild,
+    buildFailed: true
+}
+
+const longArgsBuild: BuildResult = {
+    ...successfulHelpBuild,
+    requestedTasks: 'check publishMyLongNamePluginPublicationToMavenCentral publishMyLongNamePluginPublicationToPluginPortal',
+}
+
+const scanPublishDisabledBuild: BuildResult = {
+    ...successfulHelpBuild,
+    buildScanUri: '',
+    buildScanFailed: false,
+}
+
+const scanPublishFailedBuild: BuildResult = {
+    ...successfulHelpBuild,
+    buildScanUri: '',
+    buildScanFailed: true,
+}
+
+describe('renderSummaryTable', () => {
+    describe('renders', () => {
+        it('successful build', () => {
+            const table = renderSummaryTable([successfulHelpBuild])
+            expect(table.trim()).toBe(dedent`
+                <table>
+                    <tr>
+                        <th>Gradle Root Project</th>
+                        <th>Requested Tasks</th>
+                        <th>Gradle Version</th>
+                        <th>Build Outcome</th>
+                        <th>Build Scan®</th>
+                    </tr>
+                    <tr>
+                        <td>root</td>
+                        <td>help</td>
+                        <td align='center'>8.0</td>
+                        <td align='center'>:white_check_mark:</td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                    </tr>
+                </table>
+            `);
+        })
+        it('failed build', () => {
+            const table = renderSummaryTable([failedHelpBuild])
+            expect(table.trim()).toBe(dedent`
+                <table>
+                    <tr>
+                        <th>Gradle Root Project</th>
+                        <th>Requested Tasks</th>
+                        <th>Gradle Version</th>
+                        <th>Build Outcome</th>
+                        <th>Build Scan®</th>
+                    </tr>
+                    <tr>
+                        <td>root</td>
+                        <td>help</td>
+                        <td align='center'>8.0</td>
+                        <td align='center'>:x:</td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                    </tr>
+                </table>
+            `);
+        })
+        describe('when build scan', () => {
+            it('publishing disabled', () => {
+                const table = renderSummaryTable([scanPublishDisabledBuild])
+                expect(table.trim()).toBe(dedent`
+                    <table>
+                        <tr>
+                            <th>Gradle Root Project</th>
+                            <th>Requested Tasks</th>
+                            <th>Gradle Version</th>
+                            <th>Build Outcome</th>
+                            <th>Build Scan®</th>
+                        </tr>
+                        <tr>
+                            <td>root</td>
+                            <td>help</td>
+                            <td align='center'>8.0</td>
+                            <td align='center'>:white_check_mark:</td>
+                            <td><a href="https://scans.gradle.com" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-NOT_PUBLISHED-lightgrey?logo=Gradle" alt="Build Scan NOT_PUBLISHED" /></a></td>
+                        </tr>
+                    </table>
+                `);
+            })
+            it('publishing failed', () => {
+                const table = renderSummaryTable([scanPublishFailedBuild])
+                expect(table.trim()).toBe(dedent`
+                    <table>
+                        <tr>
+                            <th>Gradle Root Project</th>
+                            <th>Requested Tasks</th>
+                            <th>Gradle Version</th>
+                            <th>Build Outcome</th>
+                            <th>Build Scan®</th>
+                        </tr>
+                        <tr>
+                            <td>root</td>
+                            <td>help</td>
+                            <td align='center'>8.0</td>
+                            <td align='center'>:white_check_mark:</td>
+                            <td><a href="https://docs.gradle.com/develocity/gradle-plugin/#troubleshooting" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISH_FAILED-orange?logo=Gradle" alt="Build Scan PUBLISH_FAILED" /></a></td>
+                        </tr>
+                    </table>
+                `);
+            })
+        })
+        it('multiple builds', () => {
+            const table = renderSummaryTable([successfulHelpBuild, failedHelpBuild])
+            expect(table.trim()).toBe(dedent`
+                <table>
+                    <tr>
+                        <th>Gradle Root Project</th>
+                        <th>Requested Tasks</th>
+                        <th>Gradle Version</th>
+                        <th>Build Outcome</th>
+                        <th>Build Scan®</th>
+                    </tr>
+                    <tr>
+                        <td>root</td>
+                        <td>help</td>
+                        <td align='center'>8.0</td>
+                        <td align='center'>:white_check_mark:</td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                    </tr>
+                    <tr>
+                        <td>root</td>
+                        <td>help</td>
+                        <td align='center'>8.0</td>
+                        <td align='center'>:x:</td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                    </tr>
+                </table>
+            `);
+        })
+        it('truncating long requested tasks', () => {
+            const table = renderSummaryTable([longArgsBuild])
+            expect(table.trim()).toBe(dedent`
+                <table>
+                    <tr>
+                        <th>Gradle Root Project</th>
+                        <th>Requested Tasks</th>
+                        <th>Gradle Version</th>
+                        <th>Build Outcome</th>
+                        <th>Build Scan®</th>
+                    </tr>
+                    <tr>
+                        <td>root</td>
+                        <td><div title='check publishMyLongNamePluginPublicationToMavenCentral publishMyLongNamePluginPublicationToPluginPortal'>check publishMyLongNamePluginPublicationToMavenCentral publ…</div></td>
+                        <td align='center'>8.0</td>
+                        <td align='center'>:white_check_mark:</td>
+                        <td><a href="https://scans.gradle.com/s/abc123" rel="nofollow" target="_blank"><img src="https://img.shields.io/badge/Build%20Scan%C2%AE-PUBLISHED-06A0CE?logo=Gradle" alt="Build Scan PUBLISHED" /></a></td>
+                    </tr>
+                </table>
+            `);
+        })
+    })
+})


### PR DESCRIPTION
Improve readability of build scan when requested tasks is very long, as agreed in #175. HTML diff for each case of job summary is clearer in cd62d9c9efc15c90df77242059b98bdaa4f39a43.

- Ensure a minimum size for the badge, at least the size of "Build scan®", by preventing a line break with `&nbsp;`
- Reduce the size of the badge by tweaking the inner text

Also fix a typo in the build shell script.