### PR TITLE
Set both DEVELOCITY_ACCESS_KEY and GRADLE_ENTERPRISE_ACCESS_KEY env vars

### DIFF
--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -157,5 +157,5 @@ jobs:
         run: gradle help
       - name: Check access key is blank (DEVELOCITY_ACCESS_KEY)
         run: "[ \"${DEVELOCITY_ACCESS_KEY}\" == \"\" ] || (echo 'DEVELOCITY_ACCESS_KEY has leaked!'; exit 1)"
-      - name: Check access key is blank (GRADLE_ENTERPRISE_ACCESS_KEY)
-        run: "[ \"${GRADLE_ENTERPRISE_ACCESS_KEY}\" == \"\" ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY has leaked!'; exit 1)"
+      - name: Check access key is not blank (GRADLE_ENTERPRISE_ACCESS_KEY)
+        run: "[ \"${GRADLE_ENTERPRISE_ACCESS_KEY}\" != \"\" ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY is still supported in v3!'; exit 1)"

--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -67,21 +67,28 @@ jobs:
       with:
         script: |
           core.setFailed('No Build Scan detected')
-    - name: Check short lived token
-      if: ${{ matrix.plugin-version == '3.17.3' }}
+    - name: Check short lived token (DEVELOCITY_ACCESS_KEY)
       run: "[ ${#DEVELOCITY_ACCESS_KEY} -gt 500 ] || (echo 'DEVELOCITY_ACCESS_KEY does not look like a short lived token'; exit 1)"
+    - name: Check short lived token (GRADLE_ENTERPRISE_ACCESS_KEY)
+      run: "[ ${#GRADLE_ENTERPRISE_ACCESS_KEY} -gt 500 ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY does not look like a short lived token'; exit 1)"
 
   inject-develocity-with-access-key:
     env:
       DEVELOCITY_INJECTION_ENABLED: true
       DEVELOCITY_URL: 'https://ge.solutions-team.gradle.com'
-      DEVELOCITY_PLUGIN_VERSION: 3.17.3
+      DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
       DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0'
     strategy:
       fail-fast: false
       matrix:
         gradle: [current, 7.6.2, 6.9.4, 5.6.4]
         os: ${{fromJSON(inputs.runner-os)}}
+        plugin-version: [3.16.2, 3.17.3]
+        include:
+          - plugin-version: 3.16.2
+            accessKeyEnv: GRADLE_ENTERPRISE_ACCESS_KEY
+          - plugin-version: 3.17.3
+            accessKeyEnv: DEVELOCITY_ACCESS_KEY
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -105,8 +112,10 @@ jobs:
         id: gradle
         working-directory: .github/workflow-samples/no-ge
         run: gradle help
-      - name: Check short lived token
+      - name: Check short lived token (DEVELOCITY_ACCESS_KEY)
         run: "[ ${#DEVELOCITY_ACCESS_KEY} -gt 500 ] || (echo 'DEVELOCITY_ACCESS_KEY does not look like a short lived token'; exit 1)"
+      - name: Check short lived token (GRADLE_ENTERPRISE_ACCESS_KEY)
+        run: "[ ${#GRADLE_ENTERPRISE_ACCESS_KEY} -gt 500 ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY does not look like a short lived token'; exit 1)"
       - name: Check Build Scan url
         if: ${{ !steps.gradle.outputs.build-scan-url }}
         uses: actions/github-script@v7
@@ -118,10 +127,21 @@ jobs:
     env:
       DEVELOCITY_INJECTION_ENABLED: true
       DEVELOCITY_URL: 'https://localhost:3333/'
-      DEVELOCITY_PLUGIN_VERSION: 3.17.3
+      DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
       DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0'
       # Access key also set as an env var, we want to check it does not leak
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      ${{matrix.accessKeyEnv}}: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gradle: [ current, 7.6.2, 6.9.4, 5.6.4 ]
+        os: ${{fromJSON(inputs.runner-os)}}
+        plugin-version: [ 3.16.2, 3.17.3 ]
+        include:
+          - plugin-version: 3.16.2
+            accessKeyEnv: GRADLE_ENTERPRISE_ACCESS_KEY
+          - plugin-version: 3.17.3
+            accessKeyEnv: DEVELOCITY_ACCESS_KEY
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -144,5 +164,7 @@ jobs:
         id: gradle
         working-directory: .github/workflow-samples/no-ge
         run: gradle help
-      - name: Check access key is blank
+      - name: Check access key is blank (DEVELOCITY_ACCESS_KEY)
         run: "[ \"${DEVELOCITY_ACCESS_KEY}\" == \"\" ] || (echo 'DEVELOCITY_ACCESS_KEY has leaked!'; exit 1)"
+      - name: Check access key is blank (GRADLE_ENTERPRISE_ACCESS_KEY)
+        run: "[ \"${GRADLE_ENTERPRISE_ACCESS_KEY}\" == \"\" ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY has leaked!'; exit 1)"

--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -84,11 +84,6 @@ jobs:
         gradle: [current, 7.6.2, 6.9.4, 5.6.4]
         os: ${{fromJSON(inputs.runner-os)}}
         plugin-version: [3.16.2, 3.17.3]
-        include:
-          - plugin-version: 3.16.2
-            accessKeyEnv: GRADLE_ENTERPRISE_ACCESS_KEY
-          - plugin-version: 3.17.3
-            accessKeyEnv: DEVELOCITY_ACCESS_KEY
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -130,18 +125,14 @@ jobs:
       DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
       DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0'
       # Access key also set as an env var, we want to check it does not leak
-      ${{matrix.accessKeyEnv}}: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     strategy:
       fail-fast: false
       matrix:
         gradle: [ current, 7.6.2, 6.9.4, 5.6.4 ]
         os: ${{fromJSON(inputs.runner-os)}}
         plugin-version: [ 3.16.2, 3.17.3 ]
-        include:
-          - plugin-version: 3.16.2
-            accessKeyEnv: GRADLE_ENTERPRISE_ACCESS_KEY
-          - plugin-version: 3.17.3
-            accessKeyEnv: DEVELOCITY_ACCESS_KEY
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/docs/deprecation-upgrade-guide.md
+++ b/docs/deprecation-upgrade-guide.md
@@ -1,9 +1,9 @@
 # Deprecation upgrade guide
 
-As these actions evolve, certain inputs, behaviour and usages are deprecated for removal. 
+As these actions evolve, certain inputs, behaviour and usages are deprecated for removal.
 Deprecated functionality will be fully supported during the current major release, and will be
-removed in the next major release. 
-Users will receive a deprecation warning when they rely on deprecated functionality, 
+removed in the next major release.
+Users will receive a deprecation warning when they rely on deprecated functionality,
 prompting them to update their workflows.
 
 ## The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`
@@ -25,10 +25,10 @@ with
 
 ## The action `gradle/wrapper-validation-action` has been replaced by `gradle/actions/wrapper-validation`
 
-To facilitate ongoing development, the `wrapper-validation-action` action implementation has been merged into 
+To facilitate ongoing development, the `wrapper-validation-action` action implementation has been merged into
 the https://github.com/gradle/actions repository, and the `gradle/wrapper-validation-action` has been replaced by the `gradle/actions/wrapper-validation` action.
 
-As of `v3.x`, the `gradle/wrapper-validation-action` and `gradle/actions/wrappper-validation` actions are 
+As of `v3.x`, the `gradle/wrapper-validation-action` and `gradle/actions/wrappper-validation` actions are
 functionally identical, and are released with the same versions.
 
 In a future major version (likely `v4.x`) we will stop releasing new versions of `gradle/wrapper-validation-action`:
@@ -143,3 +143,8 @@ to this:
     build-scan-terms-of-use-agree: "yes"
 ```
 These deprecated build-scan parameters are scheduled to be removed in `setup-gradle@v4` and `dependency-submission@v4`.
+
+## The GRADLE_ENTERPRISE_ACCESS_KEY env var is deprecated
+Gradle Enterprise has been renamed to Develocity starting from Gradle plugin 3.17 and Develocity server 2024.1.
+In v4 release of the action, it will require setting the access key with the `develocity-access-key` input and Develocity 2024.1 at least to generate short-lived tokens.
+If those requirements are not met, the `GRADLE_ENTERPRISE_ACCESS_KEY` env var will be cleared out and build scan publication or other authenticated Develocity operations won't be possible.

--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -747,8 +747,9 @@ This access key will be used during the action execution to get a short-lived to
 
 ### Short-lived access tokens
 Develocity access keys are long-lived, creating risks if they are leaked. To avoid this, users can use short-lived access tokens to authenticate with Develocity. Access tokens can be used wherever an access key would be used. Access tokens are only valid for the Develocity instance that created them.
-If a short-lived token fails to be retrieved (for example, if the Develocity server version is lower than `2024.1`), no access key will be set.
-In that case, Develocity authenticated operations like build cache read/write and build scan publication will fail without failing the build.
+If a short-lived token fails to be retrieved (for example, if the Develocity server version is lower than `2024.1`):
+ - if a `GRADLE_ENTERPRISE_ACCESS_KEY` env var has been set, we're falling back to it with a deprecation warning
+ - otherwise no access key env var will be set. In that case Develocity authenticated operations like build cache read/write and build scan publication will fail without failing the build.
 For more information on short-lived tokens, see [Develocity API documentation](https://docs.gradle.com/develocity/api-manual/#short_lived_access_tokens).
 
 ## Configuring Develocity injection

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -188,6 +188,9 @@ export enum JobSummaryOption {
 }
 
 export class BuildScanConfig {
+    static DevelocityAccessKeyEnvVar = 'DEVELOCITY_ACCESS_KEY'
+    static GradleEnterpriseAccessKeyEnvVar = 'GRADLE_ENTERPRISE_ACCESS_KEY'
+
     getBuildScanPublishEnabled(): boolean {
         return getBooleanInput('build-scan-publish') && this.verifyTermsOfUseAgreement()
     }
@@ -203,8 +206,8 @@ export class BuildScanConfig {
     getDevelocityAccessKey(): string {
         return (
             core.getInput('develocity-access-key') ||
-            process.env['DEVELOCITY_ACCESS_KEY'] ||
-            process.env['GRADLE_ENTERPRISE_ACCESS_KEY'] ||
+            process.env[BuildScanConfig.DevelocityAccessKeyEnvVar] ||
+            process.env[BuildScanConfig.GradleEnterpriseAccessKeyEnvVar] ||
             ''
         )
     }

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -201,7 +201,12 @@ export class BuildScanConfig {
     }
 
     getDevelocityAccessKey(): string {
-        return core.getInput('develocity-access-key') || process.env['DEVELOCITY_ACCESS_KEY'] || ''
+        return (
+            core.getInput('develocity-access-key') ||
+            process.env['DEVELOCITY_ACCESS_KEY'] ||
+            process.env['GRADLE_ENTERPRISE_ACCESS_KEY'] ||
+            ''
+        )
     }
 
     getDevelocityTokenExpiry(): string {

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -7,25 +7,28 @@ export async function setupToken(
     enforceUrl: string | undefined,
     develocityUrl: string | undefined
 ): Promise<void> {
-    const develocityAccesskeyEnvVar = 'DEVELOCITY_ACCESS_KEY'
     if (develocityAccessKey) {
         try {
             core.debug('Fetching short-lived token...')
             const tokens = await getToken(enforceUrl, develocityUrl, develocityAccessKey, develocityTokenExpiry)
             if (tokens != null && !tokens.isEmpty()) {
-                core.debug(`Got token(s), setting the ${develocityAccesskeyEnvVar} env var`)
+                core.debug(`Got token(s), setting the access key env vars`)
                 const token = tokens.raw()
                 core.setSecret(token)
-                core.exportVariable(develocityAccesskeyEnvVar, token)
+                exportAccessKeyEnvVars(token)
             } else {
                 // In case of not being able to generate a token we set the env variable to empty to avoid leaks
-                core.exportVariable(develocityAccesskeyEnvVar, '')
+                exportAccessKeyEnvVars('')
             }
         } catch (e) {
-            core.exportVariable(develocityAccesskeyEnvVar, '')
+            exportAccessKeyEnvVars('')
             core.warning(`Failed to fetch short-lived token, reason: ${e}`)
         }
     }
+}
+
+function exportAccessKeyEnvVars(value: string): void {
+    ;['DEVELOCITY_ACCESS_KEY', 'GRADLE_ENTERPRISE_ACCESS_KEY'].forEach(key => core.exportVariable(key, value))
 }
 
 export async function getToken(


### PR DESCRIPTION
Follow up of https://github.com/gradle/actions/pull/224, set both old and new access key env variables to either a short lived token or blank.