### PR TITLE
add missing permission for downloading dependency graph artifact

### DIFF
--- a/docs/dependency-submission.md
+++ b/docs/dependency-submission.md
@@ -367,6 +367,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: write
 
 jobs:


### PR DESCRIPTION
per https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts, `actions: read` is required. Without it the action fails after logging `Fetching artifact list for workflow ` due to `Error: HttpError: Resource not accessible by integration`