### PR TITLE
Handle missing access token don't clear access key

### DIFF
--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -155,8 +155,8 @@ jobs:
         id: gradle
         working-directory: .github/workflow-samples/no-ge
         run: gradle help
-      - name: Check access key is blank (DEVELOCITY_ACCESS_KEY)
-        run: "[ \"${DEVELOCITY_ACCESS_KEY}\" == \"\" ] || (echo 'DEVELOCITY_ACCESS_KEY has leaked!'; exit 1)"
+      - name: Check access key is not blank (DEVELOCITY_ACCESS_KEY)
+        run: "[ \"${DEVELOCITY_ACCESS_KEY}\" != \"\" ] || (echo 'using DEVELOCITY_ACCESS_KEY!'; exit 1)"
       - name: Check access key is not blank (GRADLE_ENTERPRISE_ACCESS_KEY)
         run: "[ \"${GRADLE_ENTERPRISE_ACCESS_KEY}\" != \"\" ] || (echo 'GRADLE_ENTERPRISE_ACCESS_KEY is still supported in v3!'; exit 1)"
 


### PR DESCRIPTION
If we don't retrieve the short-lived access token, we don't clear the access key and instead record a warning:

![Screenshot 2024-06-14 at 1 52 43 PM](https://github.com/gradle/actions/assets/475733/93b38c53-f0e5-4111-9b6f-b7d3b3603ce6)
