### PR TITLE
Simplify requesting short-lived Develocity access tokens

### DIFF
--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -23,16 +23,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
     maybeExportVariableNotEmpty('GRADLE_PLUGIN_REPOSITORY_USERNAME', config.getGradlePluginRepositoryUsername())
     maybeExportVariableNotEmpty('GRADLE_PLUGIN_REPOSITORY_PASSWORD', config.getGradlePluginRepositoryPassword())
 
-    setupToken(
-        config.getDevelocityAccessKey(),
-        config.getDevelocityTokenExpiry(),
-        getEnv('DEVELOCITY_ENFORCE_URL'),
-        getEnv('DEVELOCITY_URL')
-    )
-}
-
-function getEnv(variableName: string): string | undefined {
-    return process.env[variableName]
+    setupToken(config.getDevelocityAccessKey(), config.getDevelocityTokenExpiry())
 }
 
 function maybeExportVariable(variableName: string, value: unknown): void {

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -30,12 +30,14 @@ function exportAccessKeyEnvVars(value: string): void {
 }
 
 function handleMissingAccessToken(): void {
+    core.warning(`Failed to fetch short-lived token for Develocity`)
+
     if (process.env[BuildScanConfig.GradleEnterpriseAccessKeyEnvVar]) {
         // We do not clear the GRADLE_ENTERPRISE_ACCESS_KEY env var in v3, to let the users upgrade to DV 2024.1
         recordDeprecation(`The ${BuildScanConfig.GradleEnterpriseAccessKeyEnvVar} env var is deprecated`)
     }
     if (process.env[BuildScanConfig.DevelocityAccessKeyEnvVar]) {
-        core.warning(`Failed to fetch short-lived token, using Develocity Access key`)
+        core.warning(`The ${BuildScanConfig.DevelocityAccessKeyEnvVar} env var should be mapped to a short-lived token`)
     }
 }
 
@@ -50,8 +52,8 @@ export async function getToken(accessKey: string, expiry: string): Promise<Devel
     const tokens = new Array<HostnameAccessKey>()
     for (const k of develocityAccessKey.keys) {
         try {
+            core.info(`Requesting short-lived Develocity access token for ${k.hostname}`)
             const token = await shortLivedTokenClient.fetchToken(`https://${k.hostname}`, k, expiry)
-            core.info(`Obtained short-lived Develocity access token for ${k.hostname}`)
             tokens.push(token)
         } catch (e) {
             // Ignore failure to obtain token

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -37,75 +37,40 @@ describe('short lived tokens', () => {
                 message: 'connect ECONNREFUSED 127.0.0.1:3333',
                 code: 'ECONNREFUSED'
             })
-        try {
-            await getToken('true', 'http://localhost:3333', 'localhost=xyz;host1=key1', '')
-            expect('should have thrown').toBeUndefined()
-        } catch (e) {
-            // @ts-ignore
-            expect(e.code).toBe('ECONNREFUSED')
-        }
+        await expect(getToken('localhost=key0', ''))
+            .resolves
+            .toBeNull()
     })
 
-    it('get short lived token fails when request fails', async () => {
+    it('get short lived token is null when request fails', async () => {
         nock('http://dev:3333')
             .post('/api/auth/token')
             .times(3)
             .reply(500, 'Internal error')
         expect.assertions(1)
-        await expect(getToken('true', 'http://dev:3333', 'dev=xyz;host1=key1', ''))
-            .rejects
-            .toThrow('Develocity short lived token request failed http://dev:3333 with status code 500')
-    })
-
-    it('get short lived token fails when server url is not set', async () => {
-        expect.assertions(1)
-        await expect(getToken('true', undefined, 'localhost=xyz;host1=key1', ''))
-            .rejects
-            .toThrow('Develocity Server URL not configured')
-    })
-
-    it('get short lived token returns null when access key is empty', async () => {
-        expect.assertions(1)
-        await expect(getToken('true', 'http://dev:3333', '', ''))
+        await expect(getToken('dev=xyz', ''))
             .resolves
             .toBeNull()
     })
 
-    it('get short lived token fails when host cannot be extracted from server url', async () => {
+    it('get short lived token returns null when access key is empty', async () => {
         expect.assertions(1)
-        await expect(getToken('true', 'not_a_url', 'localhost=xyz;host1=key1', ''))
-            .rejects
-            .toThrow('Could not extract hostname from Develocity server URL')
+        await expect(getToken('', ''))
+            .resolves
+            .toBeNull()
     })
 
-    it('get short lived token fails when access key does not contain corresponding host', async () => {
-        expect.assertions(1)
-        await expect(getToken('true', 'http://dev', 'host1=xyz;host2=key2', ''))
-            .rejects
-            .toThrow('Could not find corresponding key for hostname dev')
-    })
-
-    it('get short lived token succeeds when enforce url is true', async () => {
+    it('get short lived token succeeds when single key is set', async () => {
         nock('https://dev')
             .post('/api/auth/token')
             .reply(200, 'token')
         expect.assertions(1)
-        await expect(getToken('true', 'https://dev', 'dev=key1;host1=key2', ''))
+        await expect(getToken('dev=key1', ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
     })
 
-    it('get short lived token succeeds when enforce url is false and single key is set', async () => {
-        nock('https://dev')
-            .post('/api/auth/token')
-            .reply(200, 'token')
-        expect.assertions(1)
-        await expect(getToken('false', 'https://dev', 'dev=key1', ''))
-            .resolves
-            .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
-    })
-
-    it('get short lived token succeeds when enforce url is false and multiple keys are set', async () => {
+    it('get short lived token succeeds when multiple keys are set', async () => {
         nock('https://dev')
             .post('/api/auth/token')
             .reply(200, 'token1')
@@ -113,12 +78,12 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('false', 'https://dev', 'dev=key1;prod=key2', ''))
+        await expect(getToken('dev=key1;prod=key2', ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
     })
 
-    it('get short lived token succeeds when enforce url is false and multiple keys are set and one is failing', async () => {
+    it('get short lived token succeeds when multiple keys are set and one is failing', async () => {
         nock('https://dev')
             .post('/api/auth/token')
             .reply(200, 'token1')
@@ -130,8 +95,23 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('false', 'https://dev', 'dev=key1;bogus=key0;prod=key2', ''))
+        await expect(getToken('dev=key1;bogus=key0;prod=key2', ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
+    })
+
+    it('get short lived token is null when multiple keys are set and all are failing', async () => {
+        nock('https://dev')
+            .post('/api/auth/token')
+            .times(3)
+            .reply(500, 'Internal Error')
+        nock('https://bogus')
+            .post('/api/auth/token')
+            .times(3)
+            .reply(500, 'Internal Error')
+        expect.assertions(1)
+        await expect(getToken('dev=key1;bogus=key0', ''))
+            .resolves
+            .toBeNull()
     })
 })


### PR DESCRIPTION
- Always fetch a token for every hostname in the access key
- Use any tokens that are successfully fetched
- Retain access key if no tokens can be fetched