### PR TITLE
Fix race condition with fetching short lived token

### DIFF
--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -23,7 +23,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
     maybeExportVariableNotEmpty('GRADLE_PLUGIN_REPOSITORY_USERNAME', config.getGradlePluginRepositoryUsername())
     maybeExportVariableNotEmpty('GRADLE_PLUGIN_REPOSITORY_PASSWORD', config.getGradlePluginRepositoryPassword())
 
-    setupToken(config.getDevelocityAccessKey(), config.getDevelocityTokenExpiry())
+    return setupToken(config.getDevelocityAccessKey(), config.getDevelocityTokenExpiry())
 }
 
 function maybeExportVariable(variableName: string, value: unknown): void {


### PR DESCRIPTION
This somehow worked before (and in our integ test) because the setup action gave enough time to let the request short-lived token return in time 🤷. 