### PR TITLE
Only fetch checksums for unknown wrapper versions

### DIFF
--- a/sources/src/wrapper-validation/validate.ts
+++ b/sources/src/wrapper-validation/validate.ts
@@ -8,7 +8,7 @@ export async function findInvalidWrapperJars(
     minWrapperCount: number,
     allowSnapshots: boolean,
     allowedChecksums: string[],
-    knownValidChecksums: Map<string, Set<string>> = checksums.KNOWN_VALID_CHECKSUMS
+    knownValidChecksums: checksums.WrapperChecksums = checksums.KNOWN_CHECKSUMS
 ): Promise<ValidationResult> {
     const wrapperJars = await find.findWrapperJars(gitRepoRoot)
     const result = new ValidationResult([], [])
@@ -21,7 +21,7 @@ export async function findInvalidWrapperJars(
         const notYetValidatedWrappers = []
         for (const wrapperJar of wrapperJars) {
             const sha = await hash.sha256File(resolve(gitRepoRoot, wrapperJar))
-            if (allowedChecksums.includes(sha) || knownValidChecksums.has(sha)) {
+            if (allowedChecksums.includes(sha) || knownValidChecksums.checksums.has(sha)) {
                 result.valid.push(new WrapperJar(wrapperJar, sha))
             } else {
                 notYetValidatedWrappers.push(new WrapperJar(wrapperJar, sha))
@@ -31,7 +31,7 @@ export async function findInvalidWrapperJars(
         // Otherwise fall back to fetching checksums from Gradle API and compare against them
         if (notYetValidatedWrappers.length > 0) {
             result.fetchedChecksums = true
-            const fetchedValidChecksums = await checksums.fetchValidChecksums(allowSnapshots)
+            const fetchedValidChecksums = await checksums.fetchUnknownChecksums(allowSnapshots)
 
             for (const wrapperJar of notYetValidatedWrappers) {
                 if (!fetchedValidChecksums.has(wrapperJar.checksum)) {

--- a/sources/src/wrapper-validation/validate.ts
+++ b/sources/src/wrapper-validation/validate.ts
@@ -31,7 +31,7 @@ export async function findInvalidWrapperJars(
         // Otherwise fall back to fetching checksums from Gradle API and compare against them
         if (notYetValidatedWrappers.length > 0) {
             result.fetchedChecksums = true
-            const fetchedValidChecksums = await checksums.fetchUnknownChecksums(allowSnapshots)
+            const fetchedValidChecksums = await checksums.fetchUnknownChecksums(allowSnapshots, knownValidChecksums)
 
             for (const wrapperJar of notYetValidatedWrappers) {
                 if (!fetchedValidChecksums.has(wrapperJar.checksum)) {

--- a/sources/test/jest/wrapper-validation/checksums.test.ts
+++ b/sources/test/jest/wrapper-validation/checksums.test.ts
@@ -6,22 +6,22 @@ jest.setTimeout(30000)
 
 test('has loaded hardcoded wrapper jars checksums', async () => {
   // Sanity check that generated checksums file is not empty and was properly imported
-  expect(checksums.KNOWN_VALID_CHECKSUMS.size).toBeGreaterThan(10)
+  expect(checksums.KNOWN_CHECKSUMS.checksums.size).toBeGreaterThan(10)
   // Verify that checksums of arbitrary versions are contained
   expect(
-    checksums.KNOWN_VALID_CHECKSUMS.get(
+    checksums.KNOWN_CHECKSUMS.checksums.get(
       '660ab018b8e319e9ae779fdb1b7ac47d0321bde953bf0eb4545f14952cfdcaa3'
     )
   ).toEqual(new Set(['4.10.3']))
   expect(
-    checksums.KNOWN_VALID_CHECKSUMS.get(
+    checksums.KNOWN_CHECKSUMS.checksums.get(
       '28b330c20a9a73881dfe9702df78d4d78bf72368e8906c70080ab6932462fe9e'
     )
   ).toEqual(new Set(['6.0-rc-1', '6.0-rc-2', '6.0-rc-3', '6.0', '6.0.1']))
 })
 
 test('fetches wrapper jars checksums', async () => {
-  const validChecksums = await checksums.fetchValidChecksums(false)
+  const validChecksums = await checksums.fetchUnknownChecksums(false, new checksums.WrapperChecksums)
   expect(validChecksums.size).toBeGreaterThan(10)
   // Verify that checksum of arbitrary version is contained
   expect(
@@ -47,7 +47,7 @@ describe('retry', () => {
           code: 'ECONNREFUSED'
         })
 
-      const validChecksums = await checksums.fetchValidChecksums(false)
+      const validChecksums = await checksums.fetchUnknownChecksums(false, new checksums.WrapperChecksums)
       expect(validChecksums.size).toBeGreaterThan(10)
       nock.isDone()
     })

--- a/sources/test/jest/wrapper-validation/validate.test.ts
+++ b/sources/test/jest/wrapper-validation/validate.test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import * as validate from '../../../src/wrapper-validation/validate'
 import {expect, test, jest} from '@jest/globals'
+import { WrapperChecksums } from '../../../src/wrapper-validation/checksums'
 
 jest.setTimeout(30000)
 
@@ -24,7 +25,7 @@ test('succeeds if all found wrapper jars are valid', async () => {
 })
 
 test('succeeds if all found wrapper jars are valid (and checksums are fetched from Gradle API)', async () => {
-  const knownValidChecksums = new Map<string, Set<string>>()
+  const knownValidChecksums = new WrapperChecksums()
   const result = await validate.findInvalidWrapperJars(
     baseDir,
     1,
@@ -32,6 +33,7 @@ test('succeeds if all found wrapper jars are valid (and checksums are fetched fr
     ['e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
     knownValidChecksums
   )
+  console.log(`fetchedChecksums = ${result.fetchedChecksums}`)
 
   expect(result.isValid()).toBe(true)
   // Should have fetched checksums because no known checksums were provided


### PR DESCRIPTION
The checksum values for most wrapper versions are hard-coded into the action. These known checksum values are first used for validation: only if none of the known values work do we download checksums.

Previously, we blindly downloaded all of the checksum values in this case: we now only download the checksums for versions that are not in our "known" set.

Fixes #171