### PR TITLE
Include RUNNER_ARCH in cache key

### DIFF
--- a/sources/src/caching/cache-key.ts
+++ b/sources/src/caching/cache-key.ts
@@ -73,7 +73,8 @@ export function getCacheKeyBase(cacheName: string, cacheProtocolVersion: string)
 
 function getCacheKeyEnvironment(): string {
     const runnerOs = process.env['RUNNER_OS'] || ''
-    return process.env[CACHE_KEY_OS_VAR] || runnerOs
+    const runnerArch = process.env['RUNNER_ARCH'] || ''
+    return process.env[CACHE_KEY_OS_VAR] || `${runnerOs}-${runnerArch}`
 }
 
 function getCacheKeyJob(): string {


### PR DESCRIPTION
Previously, including RUNNER_OS was enough to prevent leaking incompatible content between Gradle User Homes. With the introduction of macos-14, we now need to differentiate between different runner architectures as well.

Fixes #138