### PR TITLE
Split integration tests into 2 suites

### DIFF
--- a/.github/workflows/ci-integ-test-full.yml
+++ b/.github/workflows/ci-integ-test-full.yml
@@ -1,0 +1,29 @@
+name: CI-integ-test-full
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - 'dist/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: integ-test-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  caching-integ-tests:
+    uses: ./.github/workflows/suite-integ-test-caching.yml
+    with:
+      runner-os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist: true
+    secrets: inherit
+
+  other-integ-tests:
+    uses: ./.github/workflows/suite-integ-test-other.yml
+    with:
+      runner-os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+      skip-dist: true
+    secrets: inherit

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -8,42 +8,18 @@ on:
     - 'main'
     - 'release/**'
     - 'dev/**' # Allow running tests on dev branches without a PR
+    paths-ignore:
+    - 'dist/**'
+
+permissions:
+  contents: write
 
 concurrency:
-  group: integ-tests-${{ github.ref }}
+  group: integ-test-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  determine-suite:
-    runs-on: ubuntu-latest
-    outputs:
-      runner-os: ${{ steps.determine-suite.outputs.suite == 'quick' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]' }}
-      suite: ${{ steps.determine-suite.outputs.suite }}
-    steps:
-    - name: Determine suite to run
-      id: determine-suite
-      run: |
-        # Always run quick suite if we are not in the core `gradle/actions` repository
-        # This reduces the load for developers working on 'main' on forks
-        if [ "${{ github.repository }}" != "gradle/actions" ]; then
-          echo "Not in core repository: suite=quick"
-          echo "suite=quick" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # Run full suite for push trigger with "[bot] Update dist directory" commit message
-        if [ "${{ github.event.head_commit.message }}" == "[bot] Update dist directory" ]; then
-          echo "Bot commit to main branch: suite=full"
-          echo "suite=full" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # Run quick suite for everything else
-        echo "Everything else: suite=quick"
-        echo "suite=quick" >> "$GITHUB_OUTPUT"
-
   build-distribution:
-    needs: [determine-suite]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -52,125 +28,16 @@ jobs:
       if: ${{ needs.determine-suite.outputs.suite != 'full' }}
       uses: ./.github/actions/build-dist
 
-  build-scan-publish:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-build-scan-publish.yml
+  caching-integ-tests:
+    needs: build-distribution
+    uses: ./.github/workflows/suite-integ-test-caching.yml
     with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
+      skip-dist: false
+    secrets: inherit
 
-  cache-cleanup:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-cache-cleanup.yml
+  other-integ-tests:
+    needs: build-distribution
+    uses: ./.github/workflows/suite-integ-test-other.yml
     with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  caching-config:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-caching-config.yml
-    with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  dependency-graph:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-dependency-graph.yml
-    permissions:
-      contents: write
-    with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  dependency-submission:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-dependency-submission.yml
-    permissions:
-      contents: write
-    with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  dependency-submission-failures:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-dependency-submission-failures.yml
-    permissions:
-      contents: write
-    with:
-      runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  develocity-injection:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-inject-develocity.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-    secrets:
-      DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
-
-  provision-gradle-versions:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-provision-gradle-versions.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  restore-configuration-cache:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-restore-configuration-cache.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-  restore-containerized-gradle-home:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-restore-containerized-gradle-home.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  restore-custom-gradle-home:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-restore-custom-gradle-home.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  restore-gradle-home:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-restore-gradle-home.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  restore-java-toolchain:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-restore-java-toolchain.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  sample-kotlin-dsl:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-sample-kotlin-dsl.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  sample-gradle-plugin:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-sample-gradle-plugin.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  toolchain-detection:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-detect-toolchains.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
-
-  wrapper-validation:
-    needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-wrapper-validation.yml
-    with:
-      skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
+      skip-dist: false
+    secrets: inherit

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       runner-os: ${{ steps.determine-suite.outputs.suite == 'quick' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]' }}
-      cache-key-prefix: '0' # TODO DAZ Try this again ${{ steps.determine-suite.outputs.suite == 'quick' && '0' || github.run_number }}
       suite: ${{ steps.determine-suite.outputs.suite }}
     steps:
     - name: Determine suite to run
@@ -58,7 +57,6 @@ jobs:
     uses: ./.github/workflows/integ-test-build-scan-publish.yml
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   cache-cleanup:
@@ -66,7 +64,6 @@ jobs:
     uses: ./.github/workflows/integ-test-cache-cleanup.yml
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.suite}}-${{github.run_number}}-' # Requires a fresh cache entry each run
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   caching-config:
@@ -74,7 +71,6 @@ jobs:
     uses: ./.github/workflows/integ-test-caching-config.yml
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-graph:
@@ -85,7 +81,6 @@ jobs:
       contents: write
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-submission:
@@ -96,7 +91,6 @@ jobs:
       contents: write
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   dependency-submission-failures:
@@ -107,7 +101,6 @@ jobs:
       contents: write
     with:
       runner-os: '${{ needs.determine-suite.outputs.runner-os }}'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   develocity-injection:
@@ -115,8 +108,6 @@ jobs:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-inject-develocity.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
@@ -125,8 +116,6 @@ jobs:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-provision-gradle-versions.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-configuration-cache:
@@ -134,8 +123,6 @@ jobs:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-configuration-cache.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -144,59 +131,46 @@ jobs:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-containerized-gradle-home.yml
     with:
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-custom-gradle-home:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-custom-gradle-home.yml
     with:
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-gradle-home:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-gradle-home.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   restore-java-toolchain:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-restore-java-toolchain.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   sample-kotlin-dsl:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-sample-kotlin-dsl.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   sample-gradle-plugin:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-sample-gradle-plugin.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   toolchain-detection:
     needs: [determine-suite, build-distribution]
-    uses: ./.github/workflows/integ-test-detect-java-toolchains.yml
+    uses: ./.github/workflows/integ-test-detect-toolchains.yml
     with:
-      runner-os: '["ubuntu-latest"]'
-      cache-key-prefix: '${{ needs.determine-suite.outputs.cache-key-prefix }}-'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}
 
   wrapper-validation:
     needs: [determine-suite, build-distribution]
     uses: ./.github/workflows/integ-test-wrapper-validation.yml
     with:
-      runner-os: '["ubuntu-latest"]'
       skip-dist: ${{ needs.determine-suite.outputs.suite == 'full' }}

--- a/.github/workflows/integ-test-build-scan-publish.yml
+++ b/.github/workflows/integ-test-build-scan-publish.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false

--- a/.github/workflows/integ-test-cache-cleanup.yml
+++ b/.github/workflows/integ-test-cache-cleanup.yml
@@ -5,19 +5,21 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
 
 env:
   SKIP_DIST: ${{ inputs.skip-dist }}
-  GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: cache-cleanup-${{ inputs.cache-key-prefix }}
+  # Requires a fresh cache entry each run
+  GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: cache-cleanup-${{ inputs.cache-key-prefix }}-${{github.run_number}}
 
 jobs:
-  full-build:
+  cache-cleanup-full-build:
     strategy:
       fail-fast: false
       matrix:
@@ -38,8 +40,8 @@ jobs:
       run: ./gradlew --no-daemon --build-cache -Dcommons_math3_version="3.1" build
 
   # Second build will use the cache from the first build, but cleanup should remove unused artifacts
-  assemble-build:
-    needs: full-build
+  cache-cleanup-assemble-build:
+    needs: cache-cleanup-full-build
     strategy:
       fail-fast: false
       matrix:
@@ -60,8 +62,8 @@ jobs:
       working-directory: sources/test/jest/resources/cache-cleanup
       run: ./gradlew --no-daemon --build-cache -Dcommons_math3_version="3.1.1" build
 
-  check-clean-cache:
-    needs: assemble-build
+  cache-cleanup-check-clean-cache:
+    needs: cache-cleanup-assemble-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-caching-config.yml
+++ b/.github/workflows/integ-test-caching-config.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -17,7 +18,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: caching-config-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  caching-config-seed-build:
     strategy:
       fail-fast: false
       matrix:
@@ -46,8 +47,8 @@ jobs:
       run: ./gradlew test
 
   # Test that the gradle-user-home cache will cache dependencies, by running build with --offline
-  verify-build:
-    needs: seed-build
+  caching-config-verify-build:
+    needs: caching-config-seed-build
     strategy:
       fail-fast: false
       matrix:
@@ -75,7 +76,7 @@ jobs:
       run: ./gradlew test --offline
 
   # Test that build scans are captured when caching is explicitly disabled
-  cache-disabled:
+  caching-config-cache-disabled:
     strategy:
       fail-fast: false
       matrix:
@@ -103,7 +104,7 @@ jobs:
           core.setFailed('No Build Scan detected')
 
   # Test that build scans are captured when caching is disabled because Gradle User Home already exists
-  cache-disabled-pre-existing-gradle-home:
+  caching-config-cache-disabled-pre-existing-gradle-home:
     runs-on: ubuntu-latest # This test only runs on Ubuntu
     steps:
     - name: Checkout sources
@@ -127,9 +128,9 @@ jobs:
           core.setFailed('No Build Scan detected')
 
   # Test seed the cache with cache-write-only and verify with cache-read-only
-  seed-build-write-only:
+  caching-config-seed-write-only:
     env:
-      GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: ${{ inputs.cache-key-prefix }}-write-only-
+      GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: caching-config-write-only-${{ inputs.cache-key-prefix }}
     strategy:
       fail-fast: false
       matrix:
@@ -149,10 +150,10 @@ jobs:
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test
 
-  verify-write-only-build:
+  caching-config-verify-write-only:
     env:
-      GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: ${{ inputs.cache-key-prefix }}-write-only-
-    needs: seed-build-write-only
+      GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: caching-config-write-only-${{ inputs.cache-key-prefix }}
+    needs: caching-config-seed-write-only
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-dependency-graph.yml
+++ b/.github/workflows/integ-test-dependency-graph.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -21,7 +22,7 @@ env:
   GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
-  groovy-upload:
+  dependency-graph-groovy-upload:
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +42,8 @@ jobs:
       run: ./gradlew build
       working-directory: .github/workflow-samples/groovy-dsl
 
-  groovy-submit:
-    needs: [groovy-upload]
+  dependency-graph-groovy-submit:
+    needs: [dependency-graph-groovy-upload]
     runs-on: "ubuntu-latest"
     steps:
     - name: Checkout sources
@@ -57,7 +58,7 @@ jobs:
       env:
         DEPENDENCY_GRAPH_DOWNLOAD_ARTIFACT_NAME: groovy-upload
 
-  kotlin-generate-and-submit:
+  dependency-graph-kotlin-generate-and-submit:
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +78,7 @@ jobs:
       run: ./gradlew build
       working-directory: .github/workflow-samples/kotlin-dsl
 
-  multiple-builds:
+  dependency-graph-multiple-builds:
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +123,7 @@ jobs:
             exit 1
         fi
         
-  config-cache:
+  dependency-graph-config-cache:
     runs-on: ubuntu-latest # Test is not compatible with Windows
     steps:
     - name: Checkout sources

--- a/.github/workflows/integ-test-dependency-submission-failures.yml
+++ b/.github/workflows/integ-test-dependency-submission-failures.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
         default: '["ubuntu-latest"]'
@@ -18,7 +19,7 @@ env:
   GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
-  failing-build:
+  dependency-submission-failures-failing-build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -47,7 +48,7 @@ jobs:
             exit 1
         fi
 
-  unsupported-gradle-version:
+  dependency-submission-failures-unsupported-gradle-version:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -76,7 +77,7 @@ jobs:
             exit 1
         fi
 
-  insufficient-permissions:
+  dependency-submission-failures-insufficient-permissions:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/integ-test-dependency-submission.yml
+++ b/.github/workflows/integ-test-dependency-submission.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -21,7 +22,7 @@ env:
   GITHUB_DEPENDENCY_GRAPH_REF: 'refs/tags/v0.0.1' # Use a different ref to avoid updating the real dependency graph for the repository
 
 jobs:
-  groovy-generate-and-upload:
+  dependency-submission-groovy-generate-and-upload:
     strategy:
       fail-fast: false
       matrix:
@@ -42,8 +43,8 @@ jobs:
       env: 
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: groovy-dependency-submission
 
-  groovy-restore-cache:
-    needs: [groovy-generate-and-upload]
+  dependency-submission-groovy-restore-cache:
+    needs: [dependency-submission-groovy-generate-and-upload]
     strategy:
       fail-fast: false
       matrix:
@@ -63,8 +64,8 @@ jobs:
       env: 
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: groovy-dependency-submission
 
-  groovy-download-and-submit:
-    needs: [groovy-generate-and-upload]
+  dependency-submission-groovy-download-and-submit:
+    needs: [dependency-submission-groovy-generate-and-upload]
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +84,7 @@ jobs:
       env:
         DEPENDENCY_GRAPH_DOWNLOAD_ARTIFACT_NAME: groovy-generate-and-upload-${{ matrix.os }}
 
-  kotlin-generate-and-submit:
+  dependency-submission-kotlin-generate-and-submit:
     strategy:
       fail-fast: false
       matrix:
@@ -100,7 +101,7 @@ jobs:
       with:
         build-root-directory: .github/workflow-samples/kotlin-dsl
 
-  multiple-builds:
+  dependency-submission-multiple-builds:
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +146,7 @@ jobs:
             exit 1
         fi
 
-  multiple-builds-upload:
+  dependency-submission-multiple-builds-upload:
     strategy:
       fail-fast: false
       matrix:
@@ -168,7 +169,7 @@ jobs:
         dependency-graph: generate-and-upload
         build-root-directory: .github/workflow-samples/groovy-dsl
 
-  config-cache:
+  dependency-submission-config-cache:
     runs-on: ubuntu-latest # Test is not compatible with Windows
     steps:
     - name: Checkout sources
@@ -203,7 +204,7 @@ jobs:
             exit 1
         fi
 
-  gradle-versions:
+  dependency-submission-gradle-versions:
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +228,7 @@ jobs:
         gradle-version: ${{ matrix.gradle }}
         build-root-directory: .github/workflow-samples/no-wrapper${{ matrix.build-root-suffix }}
 
-  with-setup-gradle:
+  dependency-submission-with-setup-gradle:
     runs-on: ubuntu-latest # Test is not compatible with Windows
     steps:
     - name: Checkout sources
@@ -262,7 +263,7 @@ jobs:
             exit 1
         fi
 
-  with-includes-and-excludes:
+  dependency-submission-with-includes-and-excludes:
     runs-on: ubuntu-latest # Test is not compatible with Windows
     steps:
     - name: Checkout sources
@@ -296,7 +297,7 @@ jobs:
         fi
 
 
-  custom-report-dir-submit:
+  dependency-submission-custom-report-dir-submit:
     strategy:
       fail-fast: false
       matrix:
@@ -330,7 +331,7 @@ jobs:
           exit 1
         fi
 
-  custom-report-dir-upload:
+  dependency-submission-custom-report-dir-upload:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -347,7 +348,7 @@ jobs:
         build-root-directory: .github/workflow-samples/groovy-dsl
 
   custom-report-dir-download-and-submit:
-    needs: custom-report-dir-upload
+    needs: [dependency-submission-custom-report-dir-upload]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/.github/workflows/integ-test-detect-toolchains.yml
+++ b/.github/workflows/integ-test-detect-toolchains.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -18,7 +19,7 @@ env:
 
 jobs:
   # Test that pre-installed runner JDKs are detected
-  pre-installed-toolchains:
+  detect-toolchains-pre-installed-jdks:
     strategy:
       fail-fast: false
       matrix:
@@ -48,7 +49,7 @@ jobs:
         grep -q 'Eclipse Temurin JDK 21' output.txt || (echo "::error::Did not detect preinstalled JDK 21" && exit 1)
 
   # Test that JDKs provisioned by setup-java are detected
-  setup-java-installed-toolchain:
+  detect-toolchains-setup-java-jdks:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false

--- a/.github/workflows/integ-test-provision-gradle-versions.yml
+++ b/.github/workflows/integ-test-provision-gradle-versions.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -69,7 +70,7 @@ jobs:
         script: |
           core.setFailed('Gradle version parameter not set correctly: value was "${{ steps.gradle-current.outputs.gradle-version }}"')    
   
-  gradle-versions:
+  provision-gradle-version:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-restore-configuration-cache.yml
+++ b/.github/workflows/integ-test-restore-configuration-cache.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -20,7 +21,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-configuration-cache-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build-groovy:
+  restore-cc-seed-build-groovy:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-groovy
     strategy:
@@ -50,11 +51,11 @@ jobs:
       working-directory: .github/workflow-samples/groovy-dsl
       run: gradle test --configuration-cache
 
-  verify-build-groovy:
+  restore-cc-verify-build-groovy:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-groovy
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB_EXECUTION: ${{github.sha}}_1
-    needs: seed-build-groovy
+    needs: restore-cc-seed-build-groovy
     strategy:
       fail-fast: false
       matrix:
@@ -91,11 +92,11 @@ jobs:
         fi
 
   # Ensure that cache-cleanup doesn't remove all necessary files
-  verify-no-cache-cleanup-groovy:
+  restore-cc-verify-no-cache-cleanup-groovy:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-groovy
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB_EXECUTION: ${{github.sha}}_2
-    needs: verify-build-groovy
+    needs: restore-cc-verify-build-groovy
     strategy:
       fail-fast: false
       matrix:
@@ -131,11 +132,11 @@ jobs:
         fi
 
   # Check that the build can run when no extracted cache entries are restored
-  gradle-user-home-not-fully-restored:
+  restore-cc-gradle-user-home-not-fully-restored:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-groovy
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB_EXECUTION: ${{github.sha}}_x
-    needs: seed-build-groovy
+    needs: restore-cc-seed-build-groovy
     strategy:
       fail-fast: false
       matrix:
@@ -164,7 +165,7 @@ jobs:
       working-directory: .github/workflow-samples/groovy-dsl
       run: gradle test --configuration-cache
 
-  seed-build-kotlin:
+  restore-cc-seed-build-kotlin:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-kotlin
     strategy:
@@ -194,11 +195,11 @@ jobs:
       working-directory: .github/workflow-samples/kotlin-dsl
       run: gradle help --configuration-cache
 
-  modify-build-kotlin:
+  restore-cc-modify-build-kotlin:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-kotlin
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB_EXECUTION: ${{github.sha}}_1
-    needs: seed-build-kotlin
+    needs: restore-cc-seed-build-kotlin
     strategy:
       fail-fast: false
       matrix:
@@ -226,11 +227,11 @@ jobs:
       run: gradle test --configuration-cache
 
   # Test restore configuration-cache from the third build invocation
-  verify-build-kotlin:
+  restore-cc-verify-build-kotlin:
     env:
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-cc-kotlin
       GRADLE_BUILD_ACTION_CACHE_KEY_JOB_EXECUTION: ${{github.sha}}_2
-    needs: modify-build-kotlin
+    needs: restore-cc-modify-build-kotlin
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-restore-containerized-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-containerized-gradle-home.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       skip-dist:
         type: boolean
         default: false
@@ -14,7 +15,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-containerized-gradle-home-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  restore-containerized-seed-build:
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
@@ -32,8 +33,8 @@ jobs:
       run: ./gradlew test
 
   # Test that the gradle-user-home cache will cache dependencies, by running build with --offline
-  dependencies-cache:
-    needs: seed-build
+  restore-containerized-dependencies-cache:
+    needs: restore-containerized-seed-build
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:

--- a/.github/workflows/integ-test-restore-custom-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-custom-gradle-home.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       skip-dist:
         type: boolean
         default: false
@@ -14,7 +15,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-custom-gradle-home-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  restore-custom-gradle-home-seed-build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -35,8 +36,8 @@ jobs:
       run: ./gradlew test --info
 
   # Test that the gradle-user-home cache will cache dependencies, by running build with --offline
-  dependencies-cache:
-    needs: seed-build
+  restore-custom-gradle-home-dependencies-cache:
+    needs: restore-custom-gradle-home-seed-build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -57,8 +58,8 @@ jobs:
       run: ./gradlew test --offline --info
 
   # Test that the gradle-user-home cache will cache and restore local build-cache
-  build-cache:
-    needs: seed-build
+  restore-custom-gradle-home-build-cache:
+    needs: restore-custom-gradle-home-seed-build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/.github/workflows/integ-test-restore-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-gradle-home.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -18,7 +19,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-gradle-home
 
 jobs:
-  seed-build:
+  restore-gradle-home-seed-build:
     strategy:
       fail-fast: false
       matrix:
@@ -39,8 +40,8 @@ jobs:
       run: ./gradlew test
 
   # Test that the gradle-user-home cache will cache dependencies, by running build with --offline
-  dependencies-cache:
-    needs: seed-build
+  restore-gradle-home-dependencies-cache:
+    needs: restore-gradle-home-seed-build
     strategy:
       fail-fast: false
       matrix:
@@ -61,8 +62,8 @@ jobs:
       run: ./gradlew test --offline
 
   # Test that the gradle-user-home cache will cache and restore local build-cache
-  build-cache:
-    needs: seed-build
+  restore-gradle-home-build-cache:
+    needs: restore-gradle-home-seed-build
     strategy:
       fail-fast: false
       matrix:
@@ -83,8 +84,8 @@ jobs:
       run: ./gradlew test -DverifyCachedBuild=true
 
   # Check that the build can run when Gradle User Home is not fully restored
-  no-extracted-cache-entries-restored:
-    needs: seed-build
+  restore-gradle-home-no-extracted-cache-entries-restored:
+    needs: restore-gradle-home-seed-build
     strategy:
       fail-fast: false
       matrix:
@@ -107,8 +108,8 @@ jobs:
       run: ./gradlew test
 
   # Test that a pre-existing gradle-user-home can be overwritten by the restored cache
-  pre-existing-gradle-home:
-    needs: seed-build
+  restore-gradle-home-pre-existing-gradle-home:
+    needs: restore-gradle-home-seed-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-restore-java-toolchain.yml
+++ b/.github/workflows/integ-test-restore-java-toolchain.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -17,7 +18,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-java-toolchain-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  restore-java-toolchain-seed-build:
     strategy:
       fail-fast: false
       matrix:
@@ -38,8 +39,8 @@ jobs:
       run: ./gradlew test --info
 
   # Test that the gradle-user-home cache will cache the toolchain, by running build with --offline
-  toolchain-cache:
-    needs: seed-build
+  restore-java-toolchain-verify-build:
+    needs: restore-java-toolchain-seed-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-sample-gradle-plugin.yml
+++ b/.github/workflows/integ-test-sample-gradle-plugin.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -17,7 +18,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: sample-gradle-plugin-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  sample-gradle-plugin-seed-build:
     strategy:
       fail-fast: false
       matrix:
@@ -37,8 +38,8 @@ jobs:
       working-directory: .github/workflow-samples/gradle-plugin
       run: ./gradlew build
 
-  verify-build:
-    needs: seed-build
+  sample-gradle-plugin-verify-build:
+    needs: sample-gradle-plugin-seed-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-sample-kotlin-dsl.yml
+++ b/.github/workflows/integ-test-sample-kotlin-dsl.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       cache-key-prefix:
         type: string
+        default: '0'
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -17,7 +18,7 @@ env:
   GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: sample-kotlin-dsl-${{ inputs.cache-key-prefix }}
 
 jobs:
-  seed-build:
+  sample-kotlin-dsl-seed-build:
     strategy:
       fail-fast: false
       matrix:
@@ -37,8 +38,8 @@ jobs:
       working-directory: .github/workflow-samples/kotlin-dsl
       run: ./gradlew build
 
-  verify-build:
-    needs: seed-build
+  sample-kotlin-dsl-verify-build:
+    needs: sample-kotlin-dsl-seed-build
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integ-test-wrapper-validation.yml
+++ b/.github/workflows/integ-test-wrapper-validation.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner-os:
         type: string
-        default: '["ubuntu-latest", "windows-latest", "macos-latest"]'
+        default: '["ubuntu-latest"]'
       skip-dist:
         type: boolean
         default: false
@@ -14,7 +14,7 @@ env:
   SKIP_DIST: ${{ inputs.skip-dist }}
 
 jobs:
-  test-setup-gradle-validation:
+  wrapper-validation-setup-gradle:
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
           exit 1
         fi
 
-  test-validation-success:
+  wrapper-validation-success:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -68,7 +68,7 @@ jobs:
           exit 1
         fi
 
-  test-validation-error:
+  wrapper-validation-error:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -100,7 +100,7 @@ jobs:
           exit 1
         fi
 
-  test-validation-minimum-wrapper-count:
+  wrapper-validation-minimum-wrapper-count:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -129,7 +129,7 @@ jobs:
           exit 1
         fi
 
-  test-validation-zero-wrappers:
+  wrapper-validation-zero-wrappers:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/.github/workflows/integ-test-wrapper-validation.yml
+++ b/.github/workflows/integ-test-wrapper-validation.yml
@@ -34,6 +34,7 @@ jobs:
       continue-on-error: true
 
     - name: Check failure
+      shell: bash
       run: |
         if [ "${{ steps.setup-gradle.outcome}}" != "failure" ] ; then
           echo "Expected validation to fail, but it didn't"
@@ -62,6 +63,7 @@ jobs:
         # below to not accidentally inject code into shell script or break its syntax
         FAILED_WRAPPERS: ${{ steps.action-test.outputs.failed-wrapper }}
         FAILED_WRAPPERS_MATCHES: ${{ steps.action-test.outputs.failed-wrapper == '' }}
+      shell: bash
       run: |
         if [ "$FAILED_WRAPPERS_MATCHES" != "true" ] ; then
           echo "'outputs.failed-wrapper' has unexpected content: $FAILED_WRAPPERS"
@@ -89,6 +91,7 @@ jobs:
         VALIDATION_FAILED: ${{ steps.action-test.outcome == 'failure' }}
         FAILED_WRAPPERS: ${{ steps.action-test.outputs.failed-wrapper }}
         FAILED_WRAPPERS_MATCHES: ${{ steps.action-test.outputs.failed-wrapper == 'sources/test/jest/wrapper-validation/data/invalid/gradle-wrapper.jar|sources/test/jest/wrapper-validation/data/invalid/gradlе-wrapper.jar' }}
+      shell: bash
       run: |
         if [ "$VALIDATION_FAILED" != "true" ] ; then
           echo "Expected validation to fail, but it didn't"
@@ -123,6 +126,7 @@ jobs:
         # Evaluate workflow expressions here as env variable values instead of inside shell script
         # below to not accidentally inject code into shell script or break its syntax
         VALIDATION_FAILED: ${{ steps.action-test.outcome == 'failure' }}
+      shell: bash
       run: |
         if [ "$VALIDATION_FAILED" != "true" ] ; then
           echo "Expected validation to fail, but it didn't"
@@ -153,6 +157,7 @@ jobs:
         # Evaluate workflow expressions here as env variable values instead of inside shell script
         # below to not accidentally inject code into shell script or break its syntax
         VALIDATION_FAILED: ${{ steps.action-test.outcome == 'failure' }}
+      shell: bash
       run: |
         if [ "$VALIDATION_FAILED" != "true" ] ; then
           echo "Expected validation to fail, but it didn't"

--- a/.github/workflows/suite-integ-test-caching.yml
+++ b/.github/workflows/suite-integ-test-caching.yml
@@ -1,0 +1,52 @@
+name: CI-integ-test
+
+on:
+  workflow_call:
+    inputs:
+      runner-os:
+        type: string
+        default: '["ubuntu-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
+
+jobs:
+  cache-cleanup:
+    uses: ./.github/workflows/integ-test-cache-cleanup.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  caching-config:
+    uses: ./.github/workflows/integ-test-caching-config.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  restore-configuration-cache:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/integ-test-restore-configuration-cache.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+  restore-containerized-gradle-home:
+    uses: ./.github/workflows/integ-test-restore-containerized-gradle-home.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+
+  restore-custom-gradle-home:
+    uses: ./.github/workflows/integ-test-restore-custom-gradle-home.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+
+  restore-gradle-home:
+    uses: ./.github/workflows/integ-test-restore-gradle-home.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+
+  restore-java-toolchain:
+    uses: ./.github/workflows/integ-test-restore-java-toolchain.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}

--- a/.github/workflows/suite-integ-test-other.yml
+++ b/.github/workflows/suite-integ-test-other.yml
@@ -1,0 +1,82 @@
+name: CI-integ-test
+
+on:
+  workflow_call:
+    inputs:
+      runner-os:
+        type: string
+        default: '["ubuntu-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
+
+jobs:
+  build-scan-publish:
+    uses: ./.github/workflows/integ-test-build-scan-publish.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  dependency-graph:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/integ-test-dependency-graph.yml
+    permissions:
+      contents: write
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  dependency-submission:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/integ-test-dependency-submission.yml
+    permissions:
+      contents: write
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  dependency-submission-failures:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/integ-test-dependency-submission-failures.yml
+    permissions:
+      contents: write
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  develocity-injection:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: ./.github/workflows/integ-test-inject-develocity.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+    secrets:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+
+  provision-gradle-versions:
+    uses: ./.github/workflows/integ-test-provision-gradle-versions.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  sample-kotlin-dsl:
+    uses: ./.github/workflows/integ-test-sample-kotlin-dsl.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  sample-gradle-plugin:
+    uses: ./.github/workflows/integ-test-sample-gradle-plugin.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}
+
+  toolchain-detection:
+    uses: ./.github/workflows/integ-test-detect-toolchains.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+
+  wrapper-validation:
+    uses: ./.github/workflows/integ-test-wrapper-validation.yml
+    with:
+      runner-os: '${{ inputs.runner-os }}'
+      skip-dist: ${{ inputs.skip-dist }}


### PR DESCRIPTION
This should make it easier to reduce cache-contention when running full suite.