### PR TITLE
Document that `setup-gradle` performs wrapper validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The `wrapper-validation` action validates the checksums of _all_ [Gradle Wrapper
 
 The action should be run in the root of the repository, as it will recursively search for any files named `gradle-wrapper.jar`.
 
+Starting with v4 the `setup-gradle` action will [perform wrapper validation](docs/setup-gradle.md#gradle-wrapper-validation) on each execution.
+If you are using `setup-gradle` in your workflows, it is unlikely that you will need to use the `wrapper-validation` action.
+
 ### Example workflow
 
 ```yaml

--- a/docs/wrapper-validation.md
+++ b/docs/wrapper-validation.md
@@ -4,8 +4,8 @@ This action validates the checksums of _all_ [Gradle Wrapper](https://docs.gradl
 
 The action should be run in the root of the repository, as it will recursively search for any files named `gradle-wrapper.jar`.
 
-The `setup-gradle` action will perform wrapper validation on each execution. If you are using `setup-gradle` in your
-workflows, it is unlikely that you will need to use this action.
+Starting with v4 the `setup-gradle` action will [perform wrapper validation](../docs/setup-gradle.md#gradle-wrapper-validation) on each execution.
+If you are using `setup-gradle` in your workflows, it is unlikely that you will need to use the `wrapper-validation` action.
 
 ## The Gradle Wrapper Problem in Open Source
 

--- a/wrapper-validation/README.md
+++ b/wrapper-validation/README.md
@@ -4,6 +4,9 @@ The `wrapper-validation` action validates the checksums of _all_ [Gradle Wrapper
 
 The action should be run in the root of the repository, as it will recursively search for any files named `gradle-wrapper.jar`.
 
+Starting with v4 the `setup-gradle` action will [perform wrapper validation](../docs/setup-gradle.md#gradle-wrapper-validation) on each execution.
+If you are using `setup-gradle` in your workflows, it is unlikely that you will need to use the `wrapper-validation` action.
+
 ### Example workflow
 
 ```yaml


### PR DESCRIPTION
Follow-up for #318

These changes try to make it more obvious that `setup-gradle` now performs wrapper validation and using `wrapper-validation` is not necessary anymore.

To be safe I included the version number "v4" to prevent confusion or insecure builds when v3 users read this.

Side note: While the links to `setup-gradle.md#gradle-wrapper-validation` are correct, it seems GitHub does not automatically scroll to the section, but only when you reload the page.

Any feedback is appreciated!