### PR TITLE
Increase Gradle version coverage for init-scripts

### DIFF
--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -22,19 +22,22 @@ class BaseInitScriptTest extends Specification {
     static final TestGradleVersion GRADLE_3_X = new TestGradleVersion(GradleVersion.version('3.5.1'), 7, 9)
     static final TestGradleVersion GRADLE_4_X = new TestGradleVersion(GradleVersion.version('4.10.3'), 7, 10)
     static final TestGradleVersion GRADLE_5_X = new TestGradleVersion(GradleVersion.version('5.6.4'), 8, 12)
+    static final TestGradleVersion GRADLE_6_0 = new TestGradleVersion(GradleVersion.version('6.0.1'), 8, 13)
     static final TestGradleVersion GRADLE_6_NO_BUILD_SERVICE = new TestGradleVersion(GradleVersion.version('6.5.1'), 8, 14)
     static final TestGradleVersion GRADLE_6_X = new TestGradleVersion(GradleVersion.version('6.9.4'), 8, 15)
-    static final TestGradleVersion GRADLE_7_1 = new TestGradleVersion(GradleVersion.version('7.6.2'), 8, 19)
+    static final TestGradleVersion GRADLE_7_1 = new TestGradleVersion(GradleVersion.version('7.1.1'), 8, 16)
     static final TestGradleVersion GRADLE_7_X = new TestGradleVersion(GradleVersion.version('7.6.2'), 8, 19)
     static final TestGradleVersion GRADLE_8_0 = new TestGradleVersion(GradleVersion.version('8.0.2'), 8, 19)
-    static final TestGradleVersion GRADLE_8_X = new TestGradleVersion(GradleVersion.version('8.10'), 8, 22)
+    static final TestGradleVersion GRADLE_8_X = new TestGradleVersion(GradleVersion.version('8.10'), 8, 23)
 
     static final List<TestGradleVersion> ALL_VERSIONS = [
         GRADLE_3_X, // First version where TestKit supports environment variables
         GRADLE_4_X,
         GRADLE_5_X,
+        GRADLE_6_0,
         GRADLE_6_NO_BUILD_SERVICE, // Last version without build service support
         GRADLE_6_X,
+        GRADLE_7_1,
         GRADLE_7_X,
         GRADLE_8_0,
         GRADLE_8_X,
@@ -44,7 +47,7 @@ class BaseInitScriptTest extends Specification {
         [GRADLE_7_X, GRADLE_8_0, GRADLE_8_X]
 
     static final List<TestGradleVersion> SETTINGS_PLUGIN_VERSIONS =
-        [GRADLE_6_X, GRADLE_7_X, GRADLE_8_0, GRADLE_8_X]
+        [GRADLE_6_X, GRADLE_7_1, GRADLE_7_X, GRADLE_8_0, GRADLE_8_X]
 
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
     static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'


### PR DESCRIPTION
As well as testing latest of each major version, also test early release of 6.x and 7.x