### PR TITLE
Ensure minimum Gradle version for cache-cleanup

### DIFF
--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -55,11 +55,12 @@ export class CacheCleaner {
         )
         fs.writeFileSync(path.resolve(cleanupProjectDir, 'build.gradle'), 'task("noop") {}')
 
-        const executable = await provisioner.provisionGradle('current')
+        // Gradle >= 8.9 required for cache cleanup
+        const executable = await provisioner.provisionGradleAtLeast('8.9')
 
         await core.group('Executing Gradle to clean up caches', async () => {
             core.info(`Cleaning up caches last used before ${cleanTimestamp}`)
-            await this.executeCleanupBuild(executable!, cleanupProjectDir)
+            await this.executeCleanupBuild(executable, cleanupProjectDir)
         })
     }
 

--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -2,7 +2,6 @@ import path from 'path'
 import fs from 'fs'
 import * as core from '@actions/core'
 import * as glob from '@actions/glob'
-import * as semver from 'semver'
 
 import {CacheEntryListener, CacheListener} from './cache-reporting'
 import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCache, tryDelete} from './cache-utils'
@@ -10,6 +9,7 @@ import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCa
 import {BuildResult, loadBuildResults} from '../build-results'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {getCacheKeyBase} from './cache-key'
+import { versionIsAtLeast } from '../execution/gradle'
 
 const SKIP_RESTORE_VAR = 'GRADLE_BUILD_ACTION_SKIP_RESTORE'
 const CACHE_PROTOCOL_VERSION = 'v1'
@@ -434,8 +434,7 @@ export class ConfigurationCacheEntryExtractor extends AbstractEntryExtractor {
             // If any associated build result used Gradle < 8.6, then mark it as not cacheable
             if (
                 pathResults.find(result => {
-                    const gradleVersion = semver.coerce(result.gradleVersion)
-                    return gradleVersion && semver.lt(gradleVersion, '8.6.0')
+                    return !versionIsAtLeast(result.gradleVersion, '8.6.0')
                 })
             ) {
                 core.info(

--- a/sources/src/caching/gradle-home-extry-extractor.ts
+++ b/sources/src/caching/gradle-home-extry-extractor.ts
@@ -9,7 +9,7 @@ import {cacheDebug, hashFileNames, isCacheDebuggingEnabled, restoreCache, saveCa
 import {BuildResult, loadBuildResults} from '../build-results'
 import {CacheConfig, ACTION_METADATA_DIR} from '../configuration'
 import {getCacheKeyBase} from './cache-key'
-import { versionIsAtLeast } from '../execution/gradle'
+import {versionIsAtLeast} from '../execution/gradle'
 
 const SKIP_RESTORE_VAR = 'GRADLE_BUILD_ACTION_SKIP_RESTORE'
 const CACHE_PROTOCOL_VERSION = 'v1'

--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -1,6 +1,8 @@
 import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 
+import * as semver from 'semver'
+
 import * as provisioner from './provision'
 import * as gradlew from './gradlew'
 
@@ -29,5 +31,20 @@ async function executeGradleBuild(executable: string | undefined, root: string, 
 
     if (status !== 0) {
         core.setFailed(`Gradle build failed: see console output for details`)
+    }
+}
+
+export function versionIsAtLeast(actualVersion: string, requiredVersion: string): boolean {
+    const splitVersion = actualVersion.split('-')
+    const coreVersion = splitVersion[0]
+    const prerelease = splitVersion.length > 1
+
+    const actualSemver = semver.coerce(coreVersion)!
+    const comparisonSemver = semver.coerce(requiredVersion)!
+
+    if (prerelease) {
+        return semver.gt(actualSemver, comparisonSemver)
+    } else {
+        return semver.gte(actualSemver, comparisonSemver)
     }
 }

--- a/sources/test/jest/gradle-version.test.ts
+++ b/sources/test/jest/gradle-version.test.ts
@@ -1,0 +1,41 @@
+import { versionIsAtLeast } from '../../src/execution/gradle'
+
+describe('gradle-version', () => {
+    describe('can compare to', () => {
+        it('same version', async () => {
+            expect(versionIsAtLeast('6.7.1', '6.7.1')).toBe(true)
+            expect(versionIsAtLeast('7.0', '7.0')).toBe(true)
+            expect(versionIsAtLeast('7.0', '7.0.0')).toBe(true)
+        })
+        it('newer version', async () => {
+            expect(versionIsAtLeast('6.7.1', '6.7.2')).toBe(false)
+            expect(versionIsAtLeast('7.0', '8.0')).toBe(false)
+            expect(versionIsAtLeast('7.0', '7.0.1')).toBe(false)
+        })
+        it('older version', async () => {
+            expect(versionIsAtLeast('6.7.2', '6.7.1')).toBe(true)
+            expect(versionIsAtLeast('8.0', '7.0')).toBe(true)
+            expect(versionIsAtLeast('7.0.1', '7.0')).toBe(true)
+        })
+        it('rc version', async () => {
+            expect(versionIsAtLeast('8.0.2-rc-1', '8.0.1')).toBe(true)
+            expect(versionIsAtLeast('8.0.2-rc-1', '8.0.2')).toBe(false)
+            expect(versionIsAtLeast('8.1-rc-1', '8.0')).toBe(true)
+            expect(versionIsAtLeast('8.0-rc-1', '8.0')).toBe(false)
+        })
+        it('snapshot version', async () => {
+            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.10')).toBe(true)
+            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.10.1')).toBe(true)
+            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.11')).toBe(false)
+
+            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10')).toBe(true)
+            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10.1')).toBe(true)
+            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10.2')).toBe(false)
+            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.11')).toBe(false)
+
+            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.0')).toBe(true)
+            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.0.1')).toBe(true)
+            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.1')).toBe(false)
+        })
+    })
+})

--- a/sources/test/jest/gradle-version.test.ts
+++ b/sources/test/jest/gradle-version.test.ts
@@ -1,7 +1,8 @@
-import { versionIsAtLeast } from '../../src/execution/gradle'
+import { describe } from 'node:test'
+import { versionIsAtLeast, parseGradleVersionFromOutput } from '../../src/execution/gradle'
 
-describe('gradle-version', () => {
-    describe('can compare to', () => {
+describe('gradle', () => {
+    describe('can compare version with', () => {
         it('same version', async () => {
             expect(versionIsAtLeast('6.7.1', '6.7.1')).toBe(true)
             expect(versionIsAtLeast('7.0', '7.0')).toBe(true)
@@ -38,4 +39,66 @@ describe('gradle-version', () => {
             expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.1')).toBe(false)
         })
     })
+    describe('can parse version from output', () => {
+        it('major version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 8.9
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('8.9')
+        })
+    
+        it('patch version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 8.9.1
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('8.9.1')
+        })
+    
+        it('rc version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 8.9-rc-1
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('8.9-rc-1')
+        })
+    
+        it('milestone version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 8.0-milestone-6
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('8.0-milestone-6')
+        })
+    
+        it('snapshot version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 8.10.2-20240828012138+0000
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('8.10.2-20240828012138+0000')
+        })
+    
+        it('branch version', async () => {
+            const output = `
+    ------------------------------------------------------------
+    Gradle 9.0-branch-provider_api_migration_public_api_changes-20240830060514+0000
+    ------------------------------------------------------------
+    `
+            const version = await parseGradleVersionFromOutput(output)!
+            expect(version).toBe('9.0-branch-provider_api_migration_public_api_changes-20240830060514+0000')
+        })
+    })
 })
+


### PR DESCRIPTION
Instead of always installing and using the latest Gradle version for cache cleanup, we now require at least Gradle 8.9. 

This avoids downloading and installing Gradle if the version on PATH is sufficient to perform cache cleanup.