### PR TITLE
Fix passing expiresInHours query parameter

### DIFF
--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -72,7 +72,7 @@ class ShortLivedTokenClient {
     retryInterval = 1000
 
     async fetchToken(serverUrl: string, accessKey: HostnameAccessKey, expiry: string): Promise<HostnameAccessKey> {
-        const queryParams = expiry ? `?expiresInHours${expiry}` : ''
+        const queryParams = expiry ? `?expiresInHours=${expiry}` : ''
         const sanitizedServerUrl = !serverUrl.endsWith('/') ? `${serverUrl}/` : serverUrl
         const headers = {
             'Content-Type': 'application/json',

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -114,4 +114,14 @@ describe('short lived tokens', () => {
             .resolves
             .toBeNull()
     })
+
+    it('get short lived token with custom expiry', async () => {
+        nock('https://dev')
+            .post('/api/auth/token?expiresInHours=4')
+            .reply(200, 'token')
+        expect.assertions(1)
+        await expect(getToken('dev=key1', '4'))
+            .resolves
+            .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
+    })
 })


### PR DESCRIPTION
The typo is fixed; unfortunately, it is not easy to test e2e, just provided the unit test that should have caught it.

Fixes #381 