### PR TITLE
Update build reports path for multi-project build

### DIFF
--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -502,7 +502,7 @@ jobs:
       if: always()
       with:
         name: build-reports
-        path: build/reports/
+        path: **/build/reports/
 ```
 
 ### Use of custom init-scripts in Gradle User Home


### PR DESCRIPTION
Update `Saving arbitrary build outputs` example to support multi-project Gradle builds