### PR TITLE
Fix checksum test by reducing network calls

### DIFF
--- a/sources/src/wrapper-validation/validate.ts
+++ b/sources/src/wrapper-validation/validate.ts
@@ -33,7 +33,7 @@ export async function findInvalidWrapperJars(
             const fetchedValidChecksums = await checksums.fetchUnknownChecksums(allowSnapshots, knownValidChecksums)
 
             for (const wrapperJar of notYetValidatedWrappers) {
-                if (!fetchedValidChecksums.has(wrapperJar.checksum)) {
+                if (!fetchedValidChecksums.checksums.has(wrapperJar.checksum)) {
                     result.invalid.push(wrapperJar)
                 } else {
                     result.valid.push(wrapperJar)


### PR DESCRIPTION
This test was originally starting with an empty set of checksums, leading to the download of a checksum for every released and snapshot version. This resulted in in sporadic test failures.

We now start with a known set of checksums and ensure that those that are missing are downloaded. This involved some refactoring and improvement in the way snapshot checksums are processed.