### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/dependency-submission.md
+++ b/docs/dependency-submission.md
@@ -276,7 +276,7 @@ For example, if you want to exclude dependencies resolved by the `buildSrc` proj
       uses: gradle/actions/dependency-submission@v4
       with:
         # Exclude all dependencies that originate solely in the 'buildSrc' project
-        dependency-graph-exclude-projets: ':buildSrc'
+        dependency-graph-exclude-projects: ':buildSrc'
         # Exclude dependencies that are only resolved in test classpaths
         dependency-graph-exclude-configurations: '.*[Tt]est(Compile|Runtime)Classpath'
 ```


### PR DESCRIPTION
I found a subtle typo in the `dependency-graph-exclude-projects` example which caused me some time to figure out