### PR TITLE
MultiCI: Add class wrapping cache-key generation

### DIFF
--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -10,6 +10,7 @@ import {CacheCleaner} from './cache-cleaner'
 import {DaemonController} from '../daemon-controller'
 import {CacheConfig} from '../configuration'
 import {BuildResults} from '../build-results'
+import {CacheKeyGenerator} from './cache-key'
 
 const CACHE_RESTORED_VAR = 'GRADLE_BUILD_ACTION_CACHE_RESTORED'
 
@@ -26,7 +27,8 @@ export async function restore(
     }
     core.exportVariable(CACHE_RESTORED_VAR, true)
 
-    const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig)
+    // TODO(Nava2): Move `new CacheKeyGenerator()` to a class property.
+    const gradleStateCache = new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig, new CacheKeyGenerator())
 
     if (cacheConfig.isCacheDisabled()) {
         core.info('Cache is disabled: will not restore state from previous builds.')
@@ -110,7 +112,8 @@ export async function save(
     }
 
     await core.group('Caching Gradle state', async () => {
-        return new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig).save(cacheListener)
+        const cacheKeyGenerator = new CacheKeyGenerator()
+        return new GradleUserHomeCache(userHome, gradleUserHome, cacheConfig, cacheKeyGenerator).save(cacheListener)
     })
 }
 

--- a/sources/test/jest/cache-debug.test.ts
+++ b/sources/test/jest/cache-debug.test.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import {GradleUserHomeCache} from "../../src/caching/gradle-user-home-cache"
 import {CacheConfig} from "../../src/configuration"
+import { CacheKeyGenerator } from '../../src/caching/cache-key'
 
 const testTmp = 'test/jest/tmp'
 fs.rmSync(testTmp, {recursive: true, force: true})
@@ -12,7 +13,7 @@ describe("--info and --stacktrace", () => {
             const emptyGradleHome = `${testTmp}/empty-gradle-home`
             fs.mkdirSync(emptyGradleHome, {recursive: true})
 
-            const stateCache = new GradleUserHomeCache("ignored", emptyGradleHome, new CacheConfig())
+            const stateCache = new GradleUserHomeCache("ignored", emptyGradleHome, new CacheConfig(), new CacheKeyGenerator())
             stateCache.configureInfoLogLevel()
 
             expect(fs.readFileSync(path.resolve(emptyGradleHome, "gradle.properties"), 'utf-8'))
@@ -25,7 +26,7 @@ describe("--info and --stacktrace", () => {
             fs.mkdirSync(existingGradleHome, {recursive: true})
             fs.writeFileSync(path.resolve(existingGradleHome, "gradle.properties"), "org.gradle.logging.level=debug\n")
 
-            const stateCache = new GradleUserHomeCache("ignored", existingGradleHome, new CacheConfig())
+            const stateCache = new GradleUserHomeCache("ignored", existingGradleHome, new CacheConfig(), new CacheKeyGenerator())
             stateCache.configureInfoLogLevel()
 
             expect(fs.readFileSync(path.resolve(existingGradleHome, "gradle.properties"), 'utf-8'))


### PR DESCRIPTION
In order to inject CI environment actions/context, this abstracts some free-functions into a single class to be injected.

This has no functional changes, only moving code around.

This is in support of #502. 

_Note:_ Ignoring white-space makes this PR much smaller to review. 