### PR TITLE
Avoid saving build-results for cache cleanup

### DIFF
--- a/sources/src/caching/cache-cleaner.ts
+++ b/sources/src/caching/cache-cleaner.ts
@@ -75,6 +75,7 @@ export class CacheCleaner {
             '--no-scan',
             '--build-cache',
             '-DGITHUB_DEPENDENCY_GRAPH_ENABLED=false',
+            '-DGRADLE_ACTIONS_SKIP_BUILD_RESULT_CAPTURE=true',
             'noop'
         ]
 

--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.internal.tasks.execution.*
 import org.gradle.execution.*
 import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.util.GradleVersion
+import org.slf4j.LoggerFactory
 
 settingsEvaluated { settings ->
     def projectTracker = gradle.sharedServices.registerIfAbsent("gradle-action-buildResultsRecorder", BuildResultsRecorder, { spec ->
@@ -20,6 +21,7 @@ settingsEvaluated { settings ->
 }
 
 abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder.Params>, BuildOperationListener, AutoCloseable {
+    private final logger = LoggerFactory.getLogger("gradle/actions")
     private boolean buildFailed = false
     private boolean configCacheHit = true
     interface Params extends BuildServiceParameters {
@@ -69,6 +71,7 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
             buildResultsDir.mkdirs()
             def buildResultsFile = new File(buildResultsDir, githubActionStep + getParameters().getInvocationId().get() + ".json")
             if (!buildResultsFile.exists()) {
+                logger.lifecycle("gradle/actions: Writing build results to ${buildResultsFile}")
                 buildResultsFile << groovy.json.JsonOutput.toJson(buildResults)
             }
         } catch (Exception e) {

--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
@@ -2,13 +2,20 @@
  * Capture information for each executed Gradle build to display in the job summary.
  */
 import org.gradle.util.GradleVersion
+import org.slf4j.LoggerFactory
 
+def SKIP_BUILD_CAPTURE = "GRADLE_ACTIONS_SKIP_BUILD_RESULT_CAPTURE"
 def BUILD_SCAN_PLUGIN_ID = "com.gradle.build-scan"
 def BUILD_SCAN_EXTENSION = "buildScan"
 def DEVELOCITY_PLUGIN_ID = "com.gradle.develocity"
 def DEVELOCITY_EXTENSION = "develocity"
 def GE_PLUGIN_ID = "com.gradle.enterprise"
 def GE_EXTENSION = "gradleEnterprise"
+
+if (System.properties[SKIP_BUILD_CAPTURE] ?: System.getenv(SKIP_BUILD_CAPTURE)) {
+    logger.lifecycle("gradle/actions: Not capturing build results")
+    return
+}
 
 // Only run against root build. Do not run against included builds.
 def isTopLevelBuild = gradle.getParent() == null
@@ -79,7 +86,6 @@ def captureUsingBuildService(invocationId) {
 
 void captureUsingBuildFinished(gradle, String invocationId, ResultsWriter resultsWriter) {
     gradle.buildFinished { result ->
-        println "Got buildFinished: ${result}"
         def buildResults = [
             rootProjectName: rootProject.name,
             rootProjectDir: rootProject.projectDir.absolutePath,
@@ -124,6 +130,8 @@ void captureUsingBuildScanPublished(buildScanExtension, String invocationId, Res
 }
 
 class ResultsWriter {
+    private final logger = LoggerFactory.getLogger("gradle/actions")
+
     void writeToResultsFile(String subDir, String invocationId, def content) {
         def runnerTempDir = System.getProperty("RUNNER_TEMP") ?: System.getenv("RUNNER_TEMP")
         def githubActionStep = System.getProperty("GITHUB_ACTION") ?: System.getenv("GITHUB_ACTION")
@@ -136,6 +144,7 @@ class ResultsWriter {
             buildResultsDir.mkdirs()
             def buildResultsFile = new File(buildResultsDir, githubActionStep + invocationId + ".json")
             if (!buildResultsFile.exists()) {
+                logger.lifecycle("gradle/actions: Writing build results to ${buildResultsFile}")
                 buildResultsFile << groovy.json.JsonOutput.toJson(content)
             }
         } catch (Exception e) {


### PR DESCRIPTION
The Gradle build used to perform cache-cleanup will run in the context of init-scripts
provided by the action, including those that collect build-results.
In some circumstances this can lead to unexpected results, such as saving configuration-cache
entries for cache cleanup executions.

With this change, build results will not be captured for cache-cleanup builds.