### PR TITLE
Update to CCUDGP 2.1

### DIFF
--- a/.github/workflow-samples/groovy-dsl/settings.gradle
+++ b/.github/workflow-samples/groovy-dsl/settings.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.gradle.develocity" version "3.19"
-    id "com.gradle.common-custom-user-data-gradle-plugin" version "2.0.2"
+    id "com.gradle.common-custom-user-data-gradle-plugin" version "2.1"
 }
 
 develocity {

--- a/.github/workflow-samples/kotlin-dsl/settings.gradle.kts
+++ b/.github/workflow-samples/kotlin-dsl/settings.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.gradle.develocity") version "3.19"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.0.2"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.1"
 }
 
 develocity {

--- a/.github/workflows/integ-test-inject-develocity.yml
+++ b/.github/workflows/integ-test-inject-develocity.yml
@@ -29,7 +29,7 @@ jobs:
       DEVELOCITY_INJECTION_ENABLED: true
       DEVELOCITY_URL: https://ge.solutions-team.gradle.com
       DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
-      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0.2'
+      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.1'
       ${{matrix.accessKeyEnv}}: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     strategy:
       fail-fast: false
@@ -76,7 +76,7 @@ jobs:
       DEVELOCITY_INJECTION_ENABLED: true
       DEVELOCITY_URL: 'https://ge.solutions-team.gradle.com'
       DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
-      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0.2'
+      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.1'
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
       DEVELOCITY_INJECTION_ENABLED: true
       DEVELOCITY_URL: 'https://localhost:3333/'
       DEVELOCITY_PLUGIN_VERSION: ${{ matrix.plugin-version }}
-      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.0.2'
+      DEVELOCITY_CCUD_PLUGIN_VERSION: '2.1'
       # Access key also set as an env var, we want to check it does not leak
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -902,7 +902,7 @@ Here's an example using the env vars:
         DEVELOCITY_URL: https://develocity.your-server.com
         DEVELOCITY_ENFORCE_URL: true
         DEVELOCITY_PLUGIN_VERSION: "3.19"
-        DEVELOCITY_CCUD_PLUGIN_VERSION: "2.0.2"
+        DEVELOCITY_CCUD_PLUGIN_VERSION: "2.1"
 ```
 
 # Dependency verification

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -23,7 +23,7 @@ export async function setup(config: BuildScanConfig): Promise<void> {
     if (config.getBuildScanPublishEnabled()) {
         maybeExportVariable('DEVELOCITY_INJECTION_ENABLED', 'true')
         maybeExportVariable('DEVELOCITY_PLUGIN_VERSION', '3.19')
-        maybeExportVariable('DEVELOCITY_CCUD_PLUGIN_VERSION', '2.0.2')
+        maybeExportVariable('DEVELOCITY_CCUD_PLUGIN_VERSION', '2.1')
         maybeExportVariable('DEVELOCITY_TERMS_OF_USE_URL', config.getBuildScanTermsOfUseUrl())
         maybeExportVariable('DEVELOCITY_TERMS_OF_USE_AGREE', config.getBuildScanTermsOfUseAgree())
     }

--- a/sources/test/init-scripts/settings.gradle
+++ b/sources/test/init-scripts/settings.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.gradle.develocity" version "3.19"
-    id "com.gradle.common-custom-user-data-gradle-plugin" version "2.0.2"
+    id "com.gradle.common-custom-user-data-gradle-plugin" version "2.1"
 }
 
 develocity {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -17,7 +17,7 @@ import java.util.zip.GZIPOutputStream
 
 class BaseInitScriptTest extends Specification {
     static final String DEVELOCITY_PLUGIN_VERSION = '3.19'
-    static final String CCUD_PLUGIN_VERSION = '2.0.2'
+    static final String CCUD_PLUGIN_VERSION = '2.1'
 
     static final TestGradleVersion GRADLE_3_X = new TestGradleVersion(GradleVersion.version('3.5.1'), 7, 9)
     static final TestGradleVersion GRADLE_4_X = new TestGradleVersion(GradleVersion.version('4.10.3'), 7, 10)


### PR DESCRIPTION
This change primarily impacts test projects and documentation. The only material impact is that CCUD 2.1 will now be auto-applied when publishing Build Scans automatically with `build-scan-publish: true`. (Develocity injection does not hard-code any CCUD version)