### PR TITLE
Attempt to use gradle wrapper for cache cleanup

### DIFF
--- a/sources/src/execution/gradle.ts
+++ b/sources/src/execution/gradle.ts
@@ -76,28 +76,19 @@ export function versionIsAtLeast(actualVersion: string, requiredVersion: string)
     return true // Actual has no stage part or snapshot part, so it cannot be older than required.
 }
 
-export async function findGradleVersionOnPath(): Promise<GradleExecutable | undefined> {
-    const gradleExecutable = await which('gradle', {nothrow: true})
-    if (gradleExecutable) {
-        const output = await exec.getExecOutput(gradleExecutable, ['-v'], {silent: true})
-        const version = parseGradleVersionFromOutput(output.stdout)
-        return version ? new GradleExecutable(version, gradleExecutable) : undefined
-    }
+export async function findGradleExecutableOnPath(): Promise<string | null> {
+    return await which('gradle', {nothrow: true})
+}
 
-    return undefined
+export async function determineGradleVersion(gradleExecutable: string): Promise<string | undefined> {
+    const output = await exec.getExecOutput(gradleExecutable, ['-v'], {silent: true})
+    return parseGradleVersionFromOutput(output.stdout)
 }
 
 export function parseGradleVersionFromOutput(output: string): string | undefined {
     const regex = /Gradle (\d+\.\d+(\.\d+)?(-.*)?)/
     const versionString = output.match(regex)?.[1]
     return versionString
-}
-
-class GradleExecutable {
-    constructor(
-        readonly version: string,
-        readonly executable: string
-    ) {}
 }
 
 class GradleVersion {


### PR DESCRIPTION
The cache-cleanup operation works by executing Gradle on a dummy project and a custom init-script. The version of Gradle used should be at least as high as the newest version used to run a build.

Previously, if the Gradle version on PATH didn't meet this requirement, the action would download and install the required Gradle version.

With this PR, the action will now use an existing Gradle wrapper distribution if it meets the requirement. This avoids unnecessary downloads of Gradle versions that are already present on the runner.

The logic is:
- Determine the newest version of Gradle that was executed during the Job. This is the 'minimum version' for cache cleanup.
- Inspect the Gradle version on PATH and any detected wrapper scripts to see if they meet the 'minimum version'.
- The first executable that is found to meet the requirements will be used for cache-cleanup.
- If no executable is found that meets the requirements, attempt to provision Gradle with the 'minimum version'.

Fixes #515 