### PR TITLE
Choose best Gradle version to use for cache cleanup

### DIFF
--- a/.github/workflows/integ-test-provision-gradle-versions.yml
+++ b/.github/workflows/integ-test-provision-gradle-versions.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle: ["8.12", 8.9, 8.1, 7.6.4, 6.9.4, 5.6.4, 4.10.3, 3.5.1]
+        gradle: ["8.13-milestone-2", "8.12", "8.12-rc-1", 8.9, 8.1, 7.6.4, 6.9.4, 5.6.4, 4.10.3, 3.5.1]
         os: ${{fromJSON(inputs.runner-os)}}
         include:
           - java-version: 11

--- a/build
+++ b/build
@@ -36,6 +36,10 @@ case "$1" in
         npm clean-install
         npm run build
         ;;
+    test)
+        shift
+        npm test -- $@
+        ;;
     *)
         npm run build
         ;;

--- a/sources/src/build-results.ts
+++ b/sources/src/build-results.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import {versionIsAtLeast} from './execution/gradle'
 
 export interface BuildResult {
     get rootProjectName(): string
@@ -31,6 +32,18 @@ export class BuildResults {
     uniqueGradleHomes(): string[] {
         const allHomes = this.results.map(buildResult => buildResult.gradleHomeDir)
         return Array.from(new Set(allHomes))
+    }
+
+    highestGradleVersion(): string | null {
+        if (this.results.length === 0) {
+            return null
+        }
+        return this.results
+            .map(result => result.gradleVersion)
+            .reduce((maxVersion: string, currentVersion: string) => {
+                if (!maxVersion) return currentVersion
+                return versionIsAtLeast(currentVersion, maxVersion) ? currentVersion : maxVersion
+            })
     }
 }
 

--- a/sources/src/caching/caches.ts
+++ b/sources/src/caching/caches.ts
@@ -102,7 +102,7 @@ export async function save(
             cacheListener.setCacheCleanupDisabled(CLEANUP_DISABLED_DUE_TO_CONFIG_CACHE_HIT)
         } else if (cacheConfig.shouldPerformCacheCleanup(buildResults.anyFailed())) {
             cacheListener.setCacheCleanupEnabled()
-            await performCacheCleanup(gradleUserHome)
+            await performCacheCleanup(gradleUserHome, buildResults)
         } else {
             core.info('Not performing cache-cleanup due to build failure')
             cacheListener.setCacheCleanupDisabled(CLEANUP_DISABLED_DUE_TO_FAILURE)
@@ -114,10 +114,10 @@ export async function save(
     })
 }
 
-async function performCacheCleanup(gradleUserHome: string): Promise<void> {
+async function performCacheCleanup(gradleUserHome: string, buildResults: BuildResults): Promise<void> {
     const cacheCleaner = new CacheCleaner(gradleUserHome, process.env['RUNNER_TEMP']!)
     try {
-        await cacheCleaner.forceCleanup()
+        await cacheCleaner.forceCleanup(buildResults)
     } catch (e) {
         core.warning(`Cache cleanup failed. Will continue. ${String(e)}`)
     }

--- a/sources/src/execution/provision.ts
+++ b/sources/src/execution/provision.ts
@@ -88,7 +88,7 @@ async function gradleReleaseNightly(): Promise<GradleVersionInfo> {
 async function gradleRelease(version: string): Promise<GradleVersionInfo> {
     const versionInfo = await findGradleVersionDeclaration(version)
     if (!versionInfo) {
-        throw new Error(`Gradle version ${version} does not exists`)
+        throw new Error(`Gradle version ${version} does not exist`)
     }
     return versionInfo
 }

--- a/sources/test/jest/cache-cleanup.test.ts
+++ b/sources/test/jest/cache-cleanup.test.ts
@@ -28,7 +28,7 @@ test('will cleanup unused dependency jars and build-cache entries', async () => 
     expect(fs.existsSync(commonsMath311)).toBe(true)
     expect(fs.readdirSync(buildCacheDir).length).toBe(4) // gc.properties, build-cache-1.lock, and 2 task entries
 
-    await cacheCleaner.forceCleanupFilesOlderThan(timestamp)
+    await cacheCleaner.forceCleanupFilesOlderThan(timestamp, 'gradle')
 
     expect(fs.existsSync(commonsMath31)).toBe(false)
     expect(fs.existsSync(commonsMath311)).toBe(true)
@@ -68,7 +68,7 @@ test('will cleanup unused gradle versions', async () => {
     // The wrapper won't be removed if it was recently downloaded. Age it.
     setUtimes(wrapper802, new Date(Date.now() - 48 * 60 * 60 * 1000))
 
-    await cacheCleaner.forceCleanupFilesOlderThan(timestamp)
+    await cacheCleaner.forceCleanupFilesOlderThan(timestamp, 'gradle')
 
     expect(fs.existsSync(gradle802)).toBe(false)
     expect(fs.existsSync(transforms3)).toBe(false)

--- a/sources/test/jest/cache-debug.test.ts
+++ b/sources/test/jest/cache-debug.test.ts
@@ -10,7 +10,7 @@ fs.rmSync(testTmp, {recursive: true, force: true})
 
 describe("--info and --stacktrace", () => {
     describe("will be created", () => {
-        it("when gradle.properties does not exists", async () => {
+        it("when gradle.properties does not exist", async () => {
             const emptyGradleHome = `${testTmp}/empty-gradle-home`
             fs.mkdirSync(emptyGradleHome, {recursive: true})
 

--- a/sources/test/jest/gradle-version.test.ts
+++ b/sources/test/jest/gradle-version.test.ts
@@ -3,43 +3,92 @@ import {describe, expect, it} from '@jest/globals'
 import {versionIsAtLeast, parseGradleVersionFromOutput} from '../../src/execution/gradle'
 
 describe('gradle', () => {
-    describe('can compare version with', () => {
-        it('same version', async () => {
-            expect(versionIsAtLeast('6.7.1', '6.7.1')).toBe(true)
-            expect(versionIsAtLeast('7.0', '7.0')).toBe(true)
-            expect(versionIsAtLeast('7.0', '7.0.0')).toBe(true)
-        })
-        it('newer version', async () => {
-            expect(versionIsAtLeast('6.7.1', '6.7.2')).toBe(false)
-            expect(versionIsAtLeast('7.0', '8.0')).toBe(false)
-            expect(versionIsAtLeast('7.0', '7.0.1')).toBe(false)
-        })
-        it('older version', async () => {
-            expect(versionIsAtLeast('6.7.2', '6.7.1')).toBe(true)
-            expect(versionIsAtLeast('8.0', '7.0')).toBe(true)
-            expect(versionIsAtLeast('7.0.1', '7.0')).toBe(true)
-        })
-        it('rc version', async () => {
-            expect(versionIsAtLeast('8.0.2-rc-1', '8.0.1')).toBe(true)
-            expect(versionIsAtLeast('8.0.2-rc-1', '8.0.2')).toBe(false)
-            expect(versionIsAtLeast('8.1-rc-1', '8.0')).toBe(true)
-            expect(versionIsAtLeast('8.0-rc-1', '8.0')).toBe(false)
-        })
-        it('snapshot version', async () => {
-            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.10')).toBe(true)
-            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.10.1')).toBe(true)
-            expect(versionIsAtLeast('8.11-20240829002031+0000', '8.11')).toBe(false)
+    describe('can compare versions that are', () => {
+        function versionsAreOrdered(versions: string[]): void {
+            for (let i = 0; i < versions.length; i++) {
+                // Compare with all other versions
+                for (let j = 0; j < versions.length; j++) {
+                    if (i >= j) {
+                        it(`${versions[i]} is at least ${versions[j]}`, () => {
+                            expect(versionIsAtLeast(versions[i], versions[j])).toBe(true)
+                        })
+                    } else {
+                        it(`${versions[i]} is NOT at least ${versions[j]}`, () => {
+                            expect(versionIsAtLeast(versions[i], versions[j])).toBe(false)
+                        })
+                    }
+                }
+            }
+        }
 
-            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10')).toBe(true)
-            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10.1')).toBe(true)
-            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.10.2')).toBe(false)
-            expect(versionIsAtLeast('8.10.2-20240828012138+0000', '8.11')).toBe(false)
+        function versionsAreNotOrdered(versions: string[]): void {
+            for (let i = 0; i < versions.length; i++) {
+                // Compare with all other versions
+                for (let j = 0; j < versions.length; j++) {
+                    if (i !== j) {
+                        it(`${versions[i]} is NOT at least ${versions[j]}`, () => {
+                            expect(versionIsAtLeast(versions[i], versions[j])).toBe(false)
+                        })
+                    }
+                }
+            }
+        }
 
-            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.0')).toBe(true)
-            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.0.1')).toBe(true)
-            expect(versionIsAtLeast('9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.1')).toBe(false)
+        function versionsAreEqual(versions: string[]): void {
+            for (let i = 0; i < versions.length; i++) {
+                // Compare with all other versions
+                for (let j = 0; j < versions.length; j++) {
+                    it(`${versions[i]} is at least ${versions[j]}`, () => {
+                        expect(versionIsAtLeast(versions[i], versions[j])).toBe(true)
+                    })
+                }
+            }
+        }
+
+        describe('simple versions', () => {
+            versionsAreOrdered(['6.0', '6.7', '6.7.1', '6.7.2', '7.0', '7.0.1', '7.1', '8.0', '8.12.1'])
+
+            versionsAreEqual(['7.0', '7.0.0'])
+            versionsAreEqual(['7.1', '7.1.0'])
+        })
+
+        describe('rc versions', () => {
+            versionsAreOrdered([
+                '8.10', '8.11-rc-1', '8.11-rc-2', '8.11', '8.11.1-rc-1', '8.11.1'
+            ])
+        })
+
+        describe('milestone versions', () => {
+            versionsAreOrdered([
+                '8.12.1', '8.12.2-milestone-1', '8.12.2', '8.13-milestone-1', '8.13-milestone-2', '8.13'
+            ])
+            versionsAreOrdered([
+                '8.12.1', '8.12.2-milestone-1', '8.12.2-milestone-2', '8.12.2-rc-1', '8.12.2'
+            ])
+        })
+
+        describe('preview versions', () => {
+            versionsAreOrdered([
+                '8.12.1', '8.12.2-preview-1', '8.12.2', '8.13-preview-1', '8.13-preview-2', '8.13'
+            ])
+            versionsAreOrdered([
+                '8.12.1', '8.12.2-milestone-1', '8.12.2-preview-1', '8.12.2-rc-1', '8.12.2'
+            ])
+        })
+
+        describe('snapshot versions', () => {
+            versionsAreOrdered([
+                '8.10.1', '8.10.2-20240828012138+0000', '8.10.2', '8.11-20240829002031+0000', '8.11'
+            ])
+            versionsAreOrdered([
+                '9.0', '9.1-branch-provider_api_migration_public_api_changes-20240826121451+0000', '9.1'
+            ])
+            versionsAreNotOrdered([
+                '8.10.2-20240828012138+0000', '8.10.2-20240828010000+1000', '8.10.2-milestone-1'
+            ])
         })
     })
+
     describe('can parse version from output', () => {
         it('major version', async () => {
             const output = `


### PR DESCRIPTION
The cache-cleanup operation works by executing Gradle on a dummy project and a custom init-script. The init-script requires at least Gradle 8.11 to work.

Ideally, the version of Gradle used for cleanup should be no older than the newest one that wrote entries to Gradle User Home. If an older Gradle version is used for cache-cleanup, it will not remove entries written specifically for newer versions.

With this change, we now attempt to ensure that cache-cleanup is run with the best Gradle version available. We inspect the Gradle version on PATH to see if it is new enough, otherwise we will provision a Gradle version equal to the newest one that ran in the Job.

The logic is:
- Determine the newest version of Gradle that was executed during the Job. This is the 'minimum version' for cache cleanup.
- Inspect the Gradle version on PATH (if any) to see if it is equal to or newer than the 'minimum version'.
- If the version Gradle on PATH is new enough, use that version for cache-cleanup.
- If not, attempt to provision Gradle with the 'minimum version'.

Fixes #436