### PR TITLE
Uppercase cache-encryption-key

### DIFF
--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -221,7 +221,7 @@ jobs:
     - uses: gradle/actions/setup-gradle@v4
       with:
         gradle-version: 8.6
-        cache-encryption-key: ${{ secrets.GradleEncryptionKey }}
+        cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
     - run: gradle build --configuration-cache
 ```
 


### PR DESCRIPTION
It's not recommended to use camel cases in secrets.

`GradleEncryptionKey` will be auto corrected to 

<img width="853" alt="Snipaste_2025-01-24_22-35-04" src="https://github.com/user-attachments/assets/306224f8-230e-47ca-8b41-b46ab470f4ce" />
