### PR TITLE
Update docs for dependency review

### DIFF
--- a/docs/dependency-submission.md
+++ b/docs/dependency-submission.md
@@ -361,7 +361,7 @@ submitted before the dependency review can complete. The period to wait is contr
 Here's an example of a separate "Dependency Review" workflow that will wait up to 10 minutes for dependency submission to complete.
 
 ```yaml
-name: dependency-review
+name: Dependency Review
 
 on:
   pull_request:


### PR DESCRIPTION
Due to [an issue with dependency-review-action](https://github.com/gradle/actions/issues/482), the setup described in the documentation can result in duplicate dependencies being added to the dependency graph.

To avoid this, we now recommend using a common `dependency-submission` workflow for both pushes to `main` and pull requests. The `dependency-review` workflow runs on any `pull_request` but will wait for the `dependency-submission` to complete.

This setup works for both the standard setup, and for the [advanced setup for pull requests from repository forks](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#usage-with-pull-requests-from-public-forked-repositories).