### PR TITLE
Fix space assignment deprecations in init-scripts

### DIFF
--- a/.github/workflows/ci-integ-test-full.yml
+++ b/.github/workflows/ci-integ-test-full.yml
@@ -3,6 +3,8 @@ name: CI-integ-test-full
 on:
   workflow_dispatch:
   push:
+    branches:
+    - 'main'
     paths:
     - 'dist/**'
 

--- a/.github/workflows/ci-update-dist.yml
+++ b/.github/workflows/ci-update-dist.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: 
     - 'main'
+    - 'prerelease/**'
     - 'release/**'
     paths-ignore:
     - 'dist/**'

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -15,8 +15,8 @@ buildscript {
       if (pluginRepositoryUsername && pluginRepositoryPassword) {
         logger.lifecycle("Applying credentials for plugin repository: ${pluginRepositoryUrl}")
         credentials {
-          username(pluginRepositoryUsername)
-          password(pluginRepositoryPassword)
+          username = pluginRepositoryUsername
+          password = pluginRepositoryPassword
         }
         authentication {
           basic(BasicAuthentication)

--- a/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.inject-develocity.init.gradle
@@ -45,12 +45,12 @@ initscript {
 
         repositories {
             maven {
-                url pluginRepositoryUrl
+                url = pluginRepositoryUrl
                 if (pluginRepositoryUsername && pluginRepositoryPassword) {
                     logger.lifecycle("Using credentials for plugin repository")
                     credentials {
-                        username(pluginRepositoryUsername)
-                        password(pluginRepositoryPassword)
+                        username = pluginRepositoryUsername
+                        password = pluginRepositoryPassword
                     }
                     authentication {
                         basic(BasicAuthentication)


### PR DESCRIPTION
Fixes the Groovy syntax in 2 init-scripts to avoid deprecation warnings. 
The fix to the DV injection script is temporary, and will be replaced by a fix in the upstream reference script.

Fixes #541 