### PR TITLE
Catch more build failures in job summary

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
@@ -41,7 +41,8 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
             // Got EVALUATE SETTINGS event: not a config-cache hit"
             configCacheHit = false
         }
-        if (buildOperation.metadata == BuildOperationCategory.RUN_WORK) {
+        if (buildOperation.metadata == BuildOperationCategory.RUN_WORK ||
+            buildOperation.metadata == BuildOperationCategory.CONFIGURE_PROJECT) {
             if (finishEvent.failure != null) {
                 buildFailed = true
             }

--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
@@ -41,7 +41,7 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
             // Got EVALUATE SETTINGS event: not a config-cache hit"
             configCacheHit = false
         }
-        if (buildOperation.details in RunRootBuildWorkBuildOperationType.Details) {
+        if (buildOperation.metadata == BuildOperationCategory.RUN_WORK) {
             if (finishEvent.failure != null) {
                 buildFailed = true
             }

--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
@@ -41,11 +41,8 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
             // Got EVALUATE SETTINGS event: not a config-cache hit"
             configCacheHit = false
         }
-        if (buildOperation.metadata == BuildOperationCategory.RUN_WORK ||
-            buildOperation.metadata == BuildOperationCategory.CONFIGURE_PROJECT) {
-            if (finishEvent.failure != null) {
-                buildFailed = true
-            }
+        if (finishEvent.failure != null) {
+            buildFailed = true
         }
     }
 

--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture.init.gradle
@@ -25,13 +25,13 @@ if (isTopLevelBuild) {
 
     def atLeastGradle3 = version >= GradleVersion.version("3.0")
     def atLeastGradle6 = version >= GradleVersion.version("6.0")
+    def atLeastGradle7 = version >= GradleVersion.version("7.0")
 
     def invocationId = "-${System.currentTimeMillis()}"
 
     if (atLeastGradle6) {
-        // By default, use standard mechanisms to capture build results
-        def useBuildService = version >= GradleVersion.version("6.6")
-        if (useBuildService) {
+        // Use BuildService for modern Gradle versions
+        if (atLeastGradle7) {
             captureUsingBuildService(invocationId)
         } else {
             captureUsingBuildFinished(gradle, invocationId, resultsWriter)

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -41,11 +41,13 @@ class BaseInitScriptTest extends Specification {
         GRADLE_8_X,
     ]
 
+    static final List<TestGradleVersion> PROJECT_PLUGIN_VERSIONS =
+        [GRADLE_3_X, GRADLE_4_X, GRADLE_5_X]
+
     static final List<TestGradleVersion> CONFIGURATION_CACHE_VERSIONS =
         [GRADLE_7_X, GRADLE_8_0, GRADLE_8_X]
 
-    static final List<TestGradleVersion> SETTINGS_PLUGIN_VERSIONS =
-        [GRADLE_6_X, GRADLE_7_1, GRADLE_7_X, GRADLE_8_0, GRADLE_8_X]
+    static final List<TestGradleVersion> SETTINGS_PLUGIN_VERSIONS = ALL_VERSIONS - PROJECT_PLUGIN_VERSIONS
 
     static final String PUBLIC_BUILD_SCAN_ID = 'i2wepy2gr7ovw'
     static final String DEFAULT_SCAN_UPLOAD_TOKEN = 'scan-upload-token'

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy
@@ -23,7 +23,6 @@ class BaseInitScriptTest extends Specification {
     static final TestGradleVersion GRADLE_4_X = new TestGradleVersion(GradleVersion.version('4.10.3'), 7, 10)
     static final TestGradleVersion GRADLE_5_X = new TestGradleVersion(GradleVersion.version('5.6.4'), 8, 12)
     static final TestGradleVersion GRADLE_6_0 = new TestGradleVersion(GradleVersion.version('6.0.1'), 8, 13)
-    static final TestGradleVersion GRADLE_6_NO_BUILD_SERVICE = new TestGradleVersion(GradleVersion.version('6.5.1'), 8, 14)
     static final TestGradleVersion GRADLE_6_X = new TestGradleVersion(GradleVersion.version('6.9.4'), 8, 15)
     static final TestGradleVersion GRADLE_7_1 = new TestGradleVersion(GradleVersion.version('7.1.1'), 8, 16)
     static final TestGradleVersion GRADLE_7_X = new TestGradleVersion(GradleVersion.version('7.6.2'), 8, 19)
@@ -35,7 +34,6 @@ class BaseInitScriptTest extends Specification {
         GRADLE_4_X,
         GRADLE_5_X,
         GRADLE_6_0,
-        GRADLE_6_NO_BUILD_SERVICE, // Last version without build service support
         GRADLE_6_X,
         GRADLE_7_1,
         GRADLE_7_X,

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
@@ -20,7 +20,7 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         testGradleVersion << ALL_VERSIONS
     }
 
-    def "produces build results file for failing build with #testGradleVersion"() {
+    def "produces build results file for failing task with #testGradleVersion"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 
         when:
@@ -32,6 +32,22 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
 
         where:
         testGradleVersion << ALL_VERSIONS
+    }
+
+    def "produces build results file for failing configuration with #testGradleVersion"() {
+        assumeTrue testGradleVersion.compatibleWithCurrentJvm
+
+        when:
+        buildFile << '''
+throw new RuntimeException("Error in configuration")
+'''
+        runAndFail(testGradleVersion.gradleVersion)
+
+        then:
+        assertResults('expectFailure', testGradleVersion, true)
+
+        where:
+        testGradleVersion << SETTINGS_PLUGIN_VERSIONS // No build results generated for older Gradle versions
     }
 
     def "produces build results file for build that fails in included build with #testGradleVersion"() {

--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy
@@ -34,6 +34,42 @@ class TestBuildResultRecorder extends BaseInitScriptTest {
         testGradleVersion << ALL_VERSIONS
     }
 
+    def "produces build results file for build that fails in included build with #testGradleVersion"() {
+        assumeTrue testGradleVersion.compatibleWithCurrentJvm
+
+        when:
+        def includedBuildRoot = new File(testProjectDir, 'included-build')
+        includedBuildRoot.mkdir()
+        def includedSettings = new File(includedBuildRoot, 'settings.gradle')
+        def includedBuild = new File(includedBuildRoot, 'build.gradle')
+
+        includedSettings << """
+            rootProject.name = 'included-build'
+"""
+        includedBuild << '''
+task expectFailure {
+    doLast {
+        throw new RuntimeException("Expected to fail in included build")
+    }
+}
+'''
+        settingsFile << """
+includeBuild('included-build')
+"""
+        buildFile << """
+task expectFailure {
+    dependsOn(gradle.includedBuild('included-build').task(':expectFailure'))
+}
+"""
+        runAndFail(testGradleVersion.gradleVersion)
+
+        then:
+        assertResults('expectFailure', testGradleVersion, true)
+
+        where:
+        testGradleVersion << ALL_VERSIONS
+    }
+
     def "produces build results file for build with --configuration-cache on #testGradleVersion"() {
         assumeTrue testGradleVersion.compatibleWithCurrentJvm
 


### PR DESCRIPTION
By inspecting a greater range of build operations for failure, the Job summary will correctly reflect the build outcome in more circumstances.

Note that we now use the old 'buildFinished' mechanism for all Gradle versions < `7.0`, instead of using the BuildService mechanism for all Gradle versions from `6.6`. This avoids needing to deal with inconsistent build operations present in Gradle versions `[6.6, 7.0)`.

Fixes #415 