### PR TITLE
Scope captured build failures

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.build-result-capture-service.plugin.groovy
@@ -41,8 +41,11 @@ abstract class BuildResultsRecorder implements BuildService<BuildResultsRecorder
             // Got EVALUATE SETTINGS event: not a config-cache hit"
             configCacheHit = false
         }
-        if (finishEvent.failure != null) {
-            buildFailed = true
+        if (buildOperation.metadata == BuildOperationCategory.RUN_WORK ||
+            buildOperation.metadata == BuildOperationCategory.CONFIGURE_PROJECT) {
+            if (finishEvent.failure != null) {
+                buildFailed = true
+            }
         }
     }
 


### PR DESCRIPTION
Scopes the captured build failures to only `RUN_WORK` and `CONFIGURE_PROJECT`.