### PR TITLE
Ignore SSL certificate validation when fetching Develocity short-lived access token if `develocity-allow-untrusted-server` is enabled

### DIFF
--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -28,7 +28,11 @@ export async function setup(config: BuildScanConfig): Promise<void> {
         maybeExportVariable('DEVELOCITY_TERMS_OF_USE_AGREE', config.getBuildScanTermsOfUseAgree())
     }
 
-    return setupToken(config.getDevelocityAccessKey(), config.getDevelocityTokenExpiry())
+    return setupToken(
+        config.getDevelocityAccessKey(),
+        config.getDevelocityTokenExpiry(),
+        config.getDevelocityAllowUntrustedServer()
+    )
 }
 
 function maybeExportVariable(variableName: string, value: unknown): void {

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -30,8 +30,8 @@ export async function setup(config: BuildScanConfig): Promise<void> {
 
     return setupToken(
         config.getDevelocityAccessKey(),
-        config.getDevelocityTokenExpiry(),
-        config.getDevelocityAllowUntrustedServer()
+        config.getDevelocityAllowUntrustedServer(),
+        config.getDevelocityTokenExpiry()
     )
 }
 

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -67,11 +67,9 @@ export async function getToken(accessKey: string, expiry: string): Promise<Devel
 }
 
 class ShortLivedTokenClient {
-    httpc = new httpm.HttpClient(
-        'gradle/actions/setup-gradle',
-        undefined,
-        {ignoreSslError: process.env.DEVELOCITY_ALLOW_UNTRUSTED_SERVER == "true"}
-    )
+    httpc = new httpm.HttpClient('gradle/actions/setup-gradle', undefined, {
+        ignoreSslError: process.env.DEVELOCITY_ALLOW_UNTRUSTED_SERVER === 'true'
+    })
     maxRetries = 3
     retryInterval = 1000
 

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -67,7 +67,11 @@ export async function getToken(accessKey: string, expiry: string): Promise<Devel
 }
 
 class ShortLivedTokenClient {
-    httpc = new httpm.HttpClient('gradle/actions/setup-gradle')
+    httpc = new httpm.HttpClient(
+        'gradle/actions/setup-gradle',
+        undefined,
+        {ignoreSslError: process.env.DEVELOCITY_ALLOW_UNTRUSTED_SERVER == "true"}
+    )
     maxRetries = 3
     retryInterval = 1000
 

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -80,12 +80,9 @@ class ShortLivedTokenClient {
     retryInterval = 1000
 
     constructor(develocityAllowUntrustedServer: boolean | undefined) {
-        this.httpc = new httpm.HttpClient('gradle/actions/setup-gradle')
-        if (develocityAllowUntrustedServer !== undefined) {
-            this.httpc.requestOptions = {
-                ignoreSslError: develocityAllowUntrustedServer
-            }
-        }
+        this.httpc = new httpm.HttpClient('gradle/actions/setup-gradle', undefined, {
+            ignoreSslError: develocityAllowUntrustedServer
+        })
     }
 
     async fetchToken(serverUrl: string, accessKey: HostnameAccessKey, expiry: string): Promise<HostnameAccessKey> {

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -5,13 +5,13 @@ import {recordDeprecation} from '../deprecation-collector'
 
 export async function setupToken(
     develocityAccessKey: string,
-    develocityTokenExpiry: string,
-    develocityAllowUntrustedServer: boolean | undefined
+    develocityAllowUntrustedServer: boolean | undefined,
+    develocityTokenExpiry: string
 ): Promise<void> {
     if (develocityAccessKey) {
         try {
             core.debug('Fetching short-lived token...')
-            const tokens = await getToken(develocityAccessKey, develocityTokenExpiry, develocityAllowUntrustedServer)
+            const tokens = await getToken(develocityAccessKey, develocityAllowUntrustedServer, develocityTokenExpiry)
             if (tokens != null && !tokens.isEmpty()) {
                 core.debug(`Got token(s), setting the access key env vars`)
                 const token = tokens.raw()
@@ -47,12 +47,12 @@ function handleMissingAccessToken(): void {
 
 export async function getToken(
     accessKey: string,
-    expiry: string,
-    develocityAllowUntrustedServer: undefined | boolean
+    allowUntrustedServer: undefined | boolean,
+    expiry: string
 ): Promise<DevelocityAccessCredentials | null> {
     const empty: Promise<DevelocityAccessCredentials | null> = new Promise(r => r(null))
     const develocityAccessKey = DevelocityAccessCredentials.parse(accessKey)
-    const shortLivedTokenClient = new ShortLivedTokenClient(develocityAllowUntrustedServer)
+    const shortLivedTokenClient = new ShortLivedTokenClient(allowUntrustedServer)
 
     if (develocityAccessKey == null) {
         return empty

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -3,11 +3,15 @@ import * as core from '@actions/core'
 import {BuildScanConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
 
-export async function setupToken(develocityAccessKey: string, develocityTokenExpiry: string): Promise<void> {
+export async function setupToken(
+    develocityAccessKey: string,
+    develocityTokenExpiry: string,
+    develocityAllowUntrustedServer: boolean | undefined
+): Promise<void> {
     if (develocityAccessKey) {
         try {
             core.debug('Fetching short-lived token...')
-            const tokens = await getToken(develocityAccessKey, develocityTokenExpiry)
+            const tokens = await getToken(develocityAccessKey, develocityTokenExpiry, develocityAllowUntrustedServer)
             if (tokens != null && !tokens.isEmpty()) {
                 core.debug(`Got token(s), setting the access key env vars`)
                 const token = tokens.raw()
@@ -41,10 +45,14 @@ function handleMissingAccessToken(): void {
     }
 }
 
-export async function getToken(accessKey: string, expiry: string): Promise<DevelocityAccessCredentials | null> {
+export async function getToken(
+    accessKey: string,
+    expiry: string,
+    develocityAllowUntrustedServer: undefined | boolean
+): Promise<DevelocityAccessCredentials | null> {
     const empty: Promise<DevelocityAccessCredentials | null> = new Promise(r => r(null))
     const develocityAccessKey = DevelocityAccessCredentials.parse(accessKey)
-    const shortLivedTokenClient = new ShortLivedTokenClient()
+    const shortLivedTokenClient = new ShortLivedTokenClient(develocityAllowUntrustedServer)
 
     if (develocityAccessKey == null) {
         return empty
@@ -67,11 +75,18 @@ export async function getToken(accessKey: string, expiry: string): Promise<Devel
 }
 
 class ShortLivedTokenClient {
-    httpc = new httpm.HttpClient('gradle/actions/setup-gradle', undefined, {
-        ignoreSslError: process.env.DEVELOCITY_ALLOW_UNTRUSTED_SERVER === 'true'
-    })
+    httpc: httpm.HttpClient
     maxRetries = 3
     retryInterval = 1000
+
+    constructor(develocityAllowUntrustedServer: boolean | undefined) {
+        this.httpc = new httpm.HttpClient('gradle/actions/setup-gradle')
+        if (develocityAllowUntrustedServer !== undefined) {
+            this.httpc.requestOptions = {
+                ignoreSslError: develocityAllowUntrustedServer
+            }
+        }
+    }
 
     async fetchToken(serverUrl: string, accessKey: HostnameAccessKey, expiry: string): Promise<HostnameAccessKey> {
         const queryParams = expiry ? `?expiresInHours=${expiry}` : ''

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -39,7 +39,7 @@ describe('short lived tokens', () => {
                 message: 'connect ECONNREFUSED 127.0.0.1:3333',
                 code: 'ECONNREFUSED'
             })
-        await expect(getToken('localhost=key0', '', false))
+        await expect(getToken('localhost=key0', false, ''))
             .resolves
             .toBeNull()
     })
@@ -50,14 +50,14 @@ describe('short lived tokens', () => {
             .times(3)
             .reply(500, 'Internal error')
         expect.assertions(1)
-        await expect(getToken('dev=xyz', '', false))
+        await expect(getToken('dev=xyz', false, ''))
             .resolves
             .toBeNull()
     })
 
     it('get short lived token returns null when access key is empty', async () => {
         expect.assertions(1)
-        await expect(getToken('', '', false))
+        await expect(getToken('', false, ''))
             .resolves
             .toBeNull()
     })
@@ -67,7 +67,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token')
         expect.assertions(1)
-        await expect(getToken('dev=key1', '', false))
+        await expect(getToken('dev=key1', false, ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
     })
@@ -80,7 +80,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('dev=key1;prod=key2', '', false))
+        await expect(getToken('dev=key1;prod=key2', false, ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
     })
@@ -97,7 +97,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('dev=key1;bogus=key0;prod=key2', '', false))
+        await expect(getToken('dev=key1;bogus=key0;prod=key2', false, ''))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
     })
@@ -112,7 +112,7 @@ describe('short lived tokens', () => {
             .times(3)
             .reply(500, 'Internal Error')
         expect.assertions(1)
-        await expect(getToken('dev=key1;bogus=key0', '', false))
+        await expect(getToken('dev=key1;bogus=key0', false, ''))
             .resolves
             .toBeNull()
     })
@@ -122,7 +122,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token?expiresInHours=4')
             .reply(200, 'token')
         expect.assertions(1)
-        await expect(getToken('dev=key1', '4', false))
+        await expect(getToken('dev=key1', false, '4'))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
     })

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -39,7 +39,7 @@ describe('short lived tokens', () => {
                 message: 'connect ECONNREFUSED 127.0.0.1:3333',
                 code: 'ECONNREFUSED'
             })
-        await expect(getToken('localhost=key0', ''))
+        await expect(getToken('localhost=key0', '', false))
             .resolves
             .toBeNull()
     })
@@ -50,14 +50,14 @@ describe('short lived tokens', () => {
             .times(3)
             .reply(500, 'Internal error')
         expect.assertions(1)
-        await expect(getToken('dev=xyz', ''))
+        await expect(getToken('dev=xyz', '', false))
             .resolves
             .toBeNull()
     })
 
     it('get short lived token returns null when access key is empty', async () => {
         expect.assertions(1)
-        await expect(getToken('', ''))
+        await expect(getToken('', '', false))
             .resolves
             .toBeNull()
     })
@@ -67,7 +67,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token')
         expect.assertions(1)
-        await expect(getToken('dev=key1', ''))
+        await expect(getToken('dev=key1', '', false))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
     })
@@ -80,7 +80,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('dev=key1;prod=key2', ''))
+        await expect(getToken('dev=key1;prod=key2', '', false))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
     })
@@ -97,7 +97,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token')
             .reply(200, 'token2')
         expect.assertions(1)
-        await expect(getToken('dev=key1;bogus=key0;prod=key2', ''))
+        await expect(getToken('dev=key1;bogus=key0;prod=key2', '', false))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token1"}, {"hostname": "prod", "key": "token2"}]})
     })
@@ -112,7 +112,7 @@ describe('short lived tokens', () => {
             .times(3)
             .reply(500, 'Internal Error')
         expect.assertions(1)
-        await expect(getToken('dev=key1;bogus=key0', ''))
+        await expect(getToken('dev=key1;bogus=key0', '', false))
             .resolves
             .toBeNull()
     })
@@ -122,7 +122,7 @@ describe('short lived tokens', () => {
             .post('/api/auth/token?expiresInHours=4')
             .reply(200, 'token')
         expect.assertions(1)
-        await expect(getToken('dev=key1', '4'))
+        await expect(getToken('dev=key1', '4', false))
             .resolves
             .toEqual({"keys": [{"hostname": "dev", "key": "token"}]})
     })


### PR DESCRIPTION
The request for a short lived access token fails if the server certificate is self signed and `develocity-allow-untrusted-server` is set to true. 

I wasn't sure how to write a test for this since nock does not seem to support mocking a ssl error response.