### PR TITLE
Update Develocity npm agent to version `1.0.1`

### DIFF
--- a/.github/workflows/ci-check-and-unit-test.yml
+++ b/.github/workflows/ci-check-and-unit-test.yml
@@ -43,7 +43,7 @@ jobs:
         npm run compile
       working-directory: sources
       env:
-        NODE_OPTIONS: '-r @gradle/develocity-agent/preload'
+        NODE_OPTIONS: '-r @gradle-tech/develocity-agent/preload'
         DEVELOCITY_URL: 'https://ge.solutions-team.gradle.com'
         DEVELOCITY_ACCESS_KEY: '${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}'
 
@@ -52,6 +52,6 @@ jobs:
         npm test
       working-directory: sources
       env:
-        NODE_OPTIONS: '-r @gradle/develocity-agent/preload'
+        NODE_OPTIONS: '-r @gradle-tech/develocity-agent/preload'
         DEVELOCITY_URL: 'https://ge.solutions-team.gradle.com'
         DEVELOCITY_ACCESS_KEY: '${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}'

--- a/.github/workflows/ci-update-dist.yml
+++ b/.github/workflows/ci-update-dist.yml
@@ -3,7 +3,7 @@ name: CI-update-dist
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
     - 'main'
     - 'prerelease/**'
     - 'release/**'
@@ -45,7 +45,7 @@ jobs:
         npm run compile
       working-directory: sources
       env:
-        NODE_OPTIONS: '-r @gradle/develocity-agent/preload'
+        NODE_OPTIONS: '-r @gradle-tech/develocity-agent/preload'
         DEVELOCITY_URL: 'https://ge.solutions-team.gradle.com'
         DEVELOCITY_ACCESS_KEY: '${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}'
 
@@ -61,7 +61,7 @@ jobs:
         git_user_signingkey: true
         git_commit_gpgsign: true
         git_config_global: true
-    
+
     # Commit and push changes; has no effect if the files did not change
     # Important: The push event will not trigger any other workflows, see
     # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#commits-made-by-this-action-do-not-trigger-new-workflow-runs

--- a/build
+++ b/build
@@ -3,7 +3,7 @@
 cd sources
 
 if [[ -f ~/.gradle/develocity/keys.properties ]]; then
-    export NODE_OPTIONS='-r @gradle/develocity-agent/preload'
+    export NODE_OPTIONS='-r @gradle-tech/develocity-agent/preload'
     export DEVELOCITY_URL=https://ge.solutions-team.gradle.com
     export DEVELOCITY_ACCESS_KEY=$(paste -sd ';' ~/.gradle/develocity/keys.properties)
 fi

--- a/sources/jest.config.js
+++ b/sources/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   reporters: [
       'default',
-      '@gradle/develocity-agent/jest-reporter',
+      '@gradle-tech/develocity-agent/jest-reporter',
   ],
   verbose: true
 }

--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -26,7 +26,7 @@
         "which": "5.0.0"
       },
       "devDependencies": {
-        "@gradle/develocity-agent": "https://develocity-npm-pkgs.gradle.com/gradle-develocity-agent-0.10.0.tgz",
+        "@gradle-tech/develocity-agent": "1.0.1",
         "@jest/globals": "29.7.0",
         "@types/jest": "29.5.14",
         "@types/node": "20.19.0",
@@ -1237,10 +1237,10 @@
         "node": ">=14"
       }
     },
-    "node_modules/@gradle/develocity-agent": {
-      "version": "0.10.0",
-      "resolved": "https://develocity-npm-pkgs.gradle.com/gradle-develocity-agent-0.10.0.tgz",
-      "integrity": "sha512-tOz5lXftTXycWUy9AEyMWppjH6/TiKt9Q7Tg2dKusIIOgRDbRf+hEmnM/bFd/mcBJJ9I38McovmvvFtO9ueYYg==",
+    "node_modules/@gradle-tech/develocity-agent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gradle-tech/develocity-agent/-/develocity-agent-1.0.1.tgz",
+      "integrity": "sha512-wmzCSCGEA5HXfVtZZqwkcSK10gnF4s0iQsHYE0D0DSos+c/O94hJHjySIv6A+/WSEWy5NtejboakXN2eucGaTw==",
       "dev": true,
       "license": "SEE LICENSE AT https://gradle.com/help/legal-terms-of-use",
       "engines": {
@@ -1248,13 +1248,17 @@
       },
       "peerDependencies": {
         "@jest/jest-message-util": ">=28.1",
-        "@jest/reporters": ">=28.1"
+        "@jest/reporters": ">=28.1",
+        "mocha": ">=7.0.1"
       },
       "peerDependenciesMeta": {
         "@jest/jest-message-util": {
           "optional": true
         },
         "@jest/reporters": {
+          "optional": true
+        },
+        "mocha": {
           "optional": true
         }
       }

--- a/sources/package.json
+++ b/sources/package.json
@@ -48,7 +48,7 @@
     "which": "5.0.0"
   },
   "devDependencies": {
-    "@gradle/develocity-agent": "https://develocity-npm-pkgs.gradle.com/gradle-develocity-agent-0.10.0.tgz",
+    "@gradle-tech/develocity-agent": "1.0.1",
     "@jest/globals": "29.7.0",
     "@types/jest": "29.5.14",
     "@types/node": "20.19.0",


### PR DESCRIPTION
This PR updates the Develocity npm agent plugin to the newly released version `1.0.1` that is available in the public npm registry.