### PR TITLE
Adapt tests to future new Build Scan publication message

### DIFF
--- a/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
+++ b/sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestDevelocityInjection.groovy
@@ -355,7 +355,7 @@ class TestDevelocityInjection extends BaseInitScriptTest {
     }
 
     void outputContainsBuildScanUrl(BuildResult result) {
-        def opt = ['Publishing build scan...', 'Publishing Build Scan...'].stream()
+        def opt = ['Publishing build scan...', 'Publishing Build Scan...', 'Publishing Build Scan to Develocity...'].stream()
             .filter { result.output.contains("${it}\n${mockScansServer.address}s/$PUBLIC_BUILD_SCAN_ID") }.findFirst()
         assert opt.isPresent()
         def message = opt.get()


### PR DESCRIPTION
Similar to https://github.com/gradle/actions/pull/651, a new Build Scan publication message will be introduced in the next Develocity Gradle plugin. This PR just adapts the test.