### PR TITLE
Do not run setup-gradle post action if workflow is cancelled

### DIFF
--- a/setup-gradle/action.yml
+++ b/setup-gradle/action.yml
@@ -242,6 +242,7 @@ runs:
   using: 'node20'
   main: '../dist/setup-gradle/main/index.js'
   post: '../dist/setup-gradle/post/index.js'
+  post-if: '!cancelled()'
 
 branding:
   icon: 'box'


### PR DESCRIPTION
### Issue
Fixes https://github.com/gradle/actions/issues/72

### Fix
Do not run post-action if the job is cancelled

### Implementation decisions
- Completely skipping the post-actions can somehow be impacting (dependency graph and deprecations being emitted there) but that seems ok if a job is cancelled
- Post-actions could be run only upon success only of the job, but a failed build would still benefit from dependency graph , deprecations and stated to be saved)
