### PR TITLE
Handle gracefully parse errors in checksum file

### DIFF
--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -3436,9 +3436,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4936,14 +4936,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -5161,9 +5162,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -8211,9 +8212,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/sources/src/wrapper-validation/cache.ts
+++ b/sources/src/wrapper-validation/cache.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import {ACTION_METADATA_DIR} from '../configuration'
+import * as core from '@actions/core'
 
 export class ChecksumCache {
     private readonly cacheFile: string
@@ -12,7 +13,11 @@ export class ChecksumCache {
     load(): string[] {
         // Load previously validated checksums saved in Gradle User Home
         if (fs.existsSync(this.cacheFile)) {
-            return JSON.parse(fs.readFileSync(this.cacheFile, 'utf-8'))
+            try {
+                return JSON.parse(fs.readFileSync(this.cacheFile, 'utf-8'))
+            } catch (e) {
+                core.warning(`Failed to parse checksum cache file: ${e}`)
+            }
         }
         return []
     }

--- a/sources/test/jest/wrapper-validation/validate.test.ts
+++ b/sources/test/jest/wrapper-validation/validate.test.ts
@@ -4,6 +4,7 @@ import * as validate from '../../../src/wrapper-validation/validate'
 import {expect, test, jest} from '@jest/globals'
 import { WrapperChecksums, KNOWN_CHECKSUMS } from '../../../src/wrapper-validation/checksums'
 import { ChecksumCache } from '../../../src/wrapper-validation/cache'
+import { ACTION_METADATA_DIR } from '../../../src/configuration'
 
 jest.setTimeout(30000)
 
@@ -127,4 +128,15 @@ test('can save and load checksums', async () => {
 
   expect(checksumCache.load()).toEqual(['123', '456'])
   expect(fs.existsSync(cacheDir)).toBe(true)
+})
+
+test('can load empty checksum file', async () => {
+    const cacheDir = path.join(tmpDir, 'empty-wrapper-validation-cache')
+    const metadataDir = path.join(cacheDir, ACTION_METADATA_DIR)
+    const emptyChecksumFile = path.join(metadataDir, 'valid-wrappers.json')
+    fs.mkdirSync(metadataDir, { recursive: true });
+    fs.writeFileSync(emptyChecksumFile, '')
+    const checksumCache = new ChecksumCache(cacheDir)
+
+    expect(checksumCache.load()).toEqual([])
 })


### PR DESCRIPTION
fixes #727 

Note: The `package-lock.json` file modifications (results of `npm audit fix`) are not related to the fix 