### PR TITLE
prefer explicitly listed candidates over gradle on path

### DIFF
--- a/sources/src/execution/provision.ts
+++ b/sources/src/execution/provision.ts
@@ -120,7 +120,7 @@ export async function provisionGradleWithVersionAtLeast(
     candidates: string[] = []
 ): Promise<string> {
     const gradleOnPath = await findGradleExecutableOnPath()
-    const allCandidates = gradleOnPath ? [gradleOnPath, ...candidates] : candidates
+    const allCandidates = gradleOnPath ? [...candidates, gradleOnPath] : candidates
 
     return core.group(`Provision Gradle >= ${minimumVersion}`, async () => {
         for (const candidate of allCandidates) {


### PR DESCRIPTION
action should prefer to use the version specified by the user. Only if that doesn't meet the min version should the action fall back to the gradle it finds on the path

fixes #717

I don't have much experience with nodejs or writing github actions, so please let me know if anything in this PR isn't done properly. Thanks!