### PR TITLE
Bump Gradle Wrapper from 9.2.0 to 9.2.1.

### DIFF
--- a/.github/workflow-samples/java-toolchain/gradle/wrapper/gradle-wrapper.properties
+++ b/.github/workflow-samples/java-toolchain/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=df67a32e86e3276d011735facb1535f64d0d88df84fa87521e90becc2d735444
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionSha256Sum=72f44c9f8ebcb1af43838f45ee5c4aa9c5444898b3468ab3f4af7b6076c5bc3f
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Release notes of Gradle 9.2.1 can be found here:
https://docs.gradle.org/9.2.1/release-notes.html