### PR TITLE
Improve typings

### DIFF
--- a/dependency-submission/action-types.yml
+++ b/dependency-submission/action-types.yml
@@ -8,10 +8,16 @@ inputs:
     type: string
 
   dependency-resolution-task:
-    type: string
+    type: list
+    separator: ' '
+    list-item:
+      type: string
 
   additional-arguments:
-    type: string
+    type: list
+    separator: ' '
+    list-item:
+      type: string
 
   # Cache configuration
   cache-provider:
@@ -115,7 +121,7 @@ inputs:
   build-scan-terms-of-use-agree:
     type: enum
     allowed-values:
-      - 'yes'
+      - yes
 
   develocity-access-key:
     type: string

--- a/setup-gradle/action-types.yml
+++ b/setup-gradle/action-types.yml
@@ -69,6 +69,7 @@ inputs:
       - disabled
       - generate
       - generate-and-submit
+      - generate-submit-and-upload
       - generate-and-upload
       - download-and-submit
 
@@ -106,7 +107,7 @@ inputs:
   build-scan-terms-of-use-agree:
     type: enum
     allowed-values:
-      - 'yes'
+      - yes
 
   develocity-access-key:
     type: string
@@ -153,7 +154,10 @@ inputs:
 
   # Deprecated action inputs
   arguments:
-    type: string
+    type: list
+    separator: ' '
+    list-item:
+      type: string
 
   # Experimental action inputs
   gradle-home-cache-strict-match:

--- a/wrapper-validation/action-types.yml
+++ b/wrapper-validation/action-types.yml
@@ -14,4 +14,7 @@ inputs:
 
 outputs:
   failed-wrapper:
-    type: string
+    type: list
+    separator: '|'
+    list-item:
+      type: string


### PR DESCRIPTION
This PR adds a missing enum value, and makes strings that are actually delimited lists those lists, so that you for example in the generated Kotlin bindings can simply do
```kotlin
additionalArguments = listOf(
    "--info",
    "--stacktrace",
    "--show-version"
)
```
instead of needing to do
```kotlin
additionalArguments = listOf(
    "--info",
    "--stacktrace",
    "--show-version"
).joinToString(" ")
```
or writing it all in one line as one string.

This is also how the typings for older versions are in the typing catalog.

Theoretically, this is a breaking changes as the typings define the API surface of the action and from the typings bindings are generated. I'll leave it up to you how you handle it regarding version increase or when to merge.