### PR TITLE
Onboard Renovate for Develocity plugin and Gradle wrapper upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    "github>gradle/renovate-agent//presets/dv-automerge-minor.json5",
+    ":disableDependencyDashboard",
+  ],
+  // Renovate is scoped narrowly here: only the Develocity Gradle plugin (custom regex)
+  // and the Gradle wrappers in selected sample directories.
+  // Everything else (npm, github-actions, Maven coordinates) is managed by Dependabot
+  // via .github/dependabot.yml.
+  enabledManagers: ["custom.regex", "gradle-wrapper"],
+  "gradle-wrapper": {
+    fileMatch: [
+      "^\\.github/workflow-samples/gradle-plugin/gradle/wrapper/gradle-wrapper\\.properties$",
+      "^\\.github/workflow-samples/groovy-dsl/gradle/wrapper/gradle-wrapper\\.properties$",
+      "^\\.github/workflow-samples/java-toolchain/gradle/wrapper/gradle-wrapper\\.properties$",
+      "^\\.github/workflow-samples/kotlin-dsl/gradle/wrapper/gradle-wrapper\\.properties$",
+      "^\\.github/workflow-samples/non-executable-wrapper/gradle/wrapper/gradle-wrapper\\.properties$",
+      "^sources/test/init-scripts/gradle/wrapper/gradle-wrapper\\.properties$",
+    ],
+  },
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Bump Develocity Gradle plugin references in files outside Dependabot's coverage",
+      fileMatch: [
+        "^\\.github/workflows/integ-test-inject-develocity\\.yml$",
+        "^sources/src/develocity/build-scan\\.ts$",
+        "^docs/setup-gradle\\.md$",
+        "(^|/)settings\\.gradle$",
+        "(^|/)settings\\.gradle\\.kts$",
+        "(^|/)build\\.gradle$",
+        "(^|/)build\\.gradle\\.kts$",
+        "^sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest\\.groovy$",
+        "^sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder\\.groovy$",
+      ],
+      // Patterns capture any X.Y(.Z) version. The packageRules below filter to
+      // just the current 4.x line and skip the pinned 3.x legacy refs.
+      // When the plugin's major version changes, edit `matchCurrentVersion` and
+      // `allowedVersions` in the packageRules block below — no regex edits here.
+      matchStrings: [
+        "plugin-version:[^\\n]*'(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)'",
+        "DEVELOCITY_PLUGIN_VERSION[^\\n]*'(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)'",
+        "`v(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)`\\s+of\\s+the\\s+\\[Develocity Gradle plugin",
+        "id\\s+['\"]com\\.gradle\\.develocity['\"]\\s+version\\s+['\"](?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)['\"]",
+        "id\\(['\"]com\\.gradle\\.develocity['\"]\\)\\s+version\\s+['\"](?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)['\"]",
+      ],
+      depNameTemplate: "com.gradle:develocity-gradle-plugin",
+      datasourceTemplate: "maven",
+      registryUrlTemplate: "https://plugins.gradle.org/m2",
+    },
+  ],
+  packageRules: [
+    {
+      // Skip the legacy 3.16.2 references that are intentionally pinned.
+      matchManagers: ["custom.regex"],
+      matchPackageNames: ["com.gradle:develocity-gradle-plugin"],
+      matchCurrentVersion: "<4.0.0",
+      enabled: false,
+    },
+    {
+      // Current 4.x line. To start tracking the next major (5.x), replace `5.0.0`
+      // with `6.0.0` in both fields below — no regex edits needed.
+      matchManagers: ["custom.regex"],
+      matchPackageNames: ["com.gradle:develocity-gradle-plugin"],
+      matchCurrentVersion: ">=4.0.0 <5.0.0",
+      allowedVersions: "<5.0.0",
+      groupName: "Develocity Gradle plugin",
+      groupSlug: "develocity-gradle-plugin",
+    },
+    {
+      matchManagers: ["gradle-wrapper"],
+      groupName: "Gradle wrappers",
+      groupSlug: "gradle-wrappers",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Adds a narrowly-scoped `.github/renovate.json5` so this repo manages its own Develocity Gradle plugin and Gradle wrapper upgrades. Renovate is scoped via `enabledManagers` so it does not overlap with Dependabot's existing coverage.

## What Renovate will manage here

### Develocity Gradle plugin (`com.gradle:develocity-gradle-plugin`)

Custom regex managers track the plugin version across every file that hard-codes it but isn't reachable by the standard Gradle manager. The patterns capture any `X.Y(.Z)` version; the `packageRules` block below filters to the current 4.x line and skips the intentionally-pinned legacy `3.16.2` references via `matchCurrentVersion`. When the plugin's major version changes, the only edit is bumping the `<5.0.0` bounds in `packageRules` — no regex updates needed.

Files touched:

- `.github/workflows/integ-test-inject-develocity.yml` — `plugin-version: [..., '<X.Y.Z>']` matrix arrays and `- plugin-version: '<X.Y.Z>'` matrix include entries
- `sources/src/develocity/build-scan.ts` — `maybeExportVariable('DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION', '<X.Y.Z>')`
- `docs/setup-gradle.md` — three reference shapes:
    - `develocity-plugin-version: '<X.Y>'` (YAML examples in the body)
    - `` `v<X.Y.Z>` of the [Develocity Gradle plugin]`` (prose reference)
    - `DEVELOCITY_INJECTION_DEVELOCITY_PLUGIN_VERSION: '<X.Y>'` (env-var YAML example)
- `.github/workflow-samples/groovy-dsl/settings.gradle` — `id "com.gradle.develocity" version "<X.Y.Z>"`
- `.github/workflow-samples/kotlin-dsl/settings.gradle.kts` — `id("com.gradle.develocity") version "<X.Y.Z>"`
- `.github/workflow-samples/no-wrapper/settings.gradle` — same as groovy-dsl
- `.github/workflow-samples/no-wrapper-gradle-5/build.gradle` — same as groovy-dsl
- `.github/workflow-samples/non-executable-wrapper/settings.gradle` — same as groovy-dsl
- `sources/test/init-scripts/settings.gradle` — same as groovy-dsl
- `sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/BaseInitScriptTest.groovy` — `DEVELOCITY_PLUGIN_VERSION = '<X.Y.Z>'`
- `sources/test/init-scripts/src/test/groovy/com/gradle/gradlebuildaction/TestBuildResultRecorder.groovy` — `id 'com.gradle.develocity' version '<X.Y.Z>'`

All grouped under a single "Develocity Gradle plugin" PR via `groupName`.

### Gradle wrappers

The native `gradle-wrapper` manager, scoped to six specific `gradle-wrapper.properties` files:

- `.github/workflow-samples/gradle-plugin/gradle/wrapper/gradle-wrapper.properties`
- `.github/workflow-samples/groovy-dsl/gradle/wrapper/gradle-wrapper.properties`
- `.github/workflow-samples/java-toolchain/gradle/wrapper/gradle-wrapper.properties`
- `.github/workflow-samples/kotlin-dsl/gradle/wrapper/gradle-wrapper.properties`
- `.github/workflow-samples/non-executable-wrapper/gradle/wrapper/gradle-wrapper.properties`
- `sources/test/init-scripts/gradle/wrapper/gradle-wrapper.properties`

The `cache-cleanup` sample's wrapper is intentionally left unmanaged here (it's been kept current by other means). All six are grouped under a single "Gradle wrappers" PR.

## What Dependabot continues to manage

`.github/dependabot.yml` is untouched. Dependabot keeps handling:

- `npm` dependencies in `sources/`
- `github-actions` across `/`, `.github/actions/build-dist`, `.github/actions/init-integ-test`
- `gradle` (Maven coordinates) across the seven workflow-sample / init-scripts directories

## Config shape

Extends `gradle/renovate-agent//presets/dv-automerge-minor.json5` (the shared Gradle Renovate baseline — minor/patch auto-merge once status checks pass, DCO sign-off on bot commits, reviewers from CODEOWNERS), plus `config:recommended` and `:disableDependencyDashboard`.

## Verification

Once merged, the next agent run should open a "Configure Renovate" PR; after that, expect "Develocity Gradle plugin" and "Gradle wrappers" PRs to appear when newer versions are available upstream.
