### PR TITLE
Update @actions/cache and @actions/artifact, stop ignoring them in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,6 @@ updates:
       npm-dependencies:
         patterns:
         - "*"
-    ignore:
-      # Keep actions/cache and actions/artifact major aligned and force actions/cache version to match patch
-      - dependency-name: "*actions/cache*"
-      - dependency-name: "*actions/artifact*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
   - package-ecosystem: "github-actions"
     # github-actions with directory: "/" only monitors .github/workflows
     # https://github.com/dependabot/dependabot-core/issues/6345

--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/artifact": "6.1.0",
-        "@actions/cache": "6.0.0",
+        "@actions/artifact": "6.2.1",
+        "@actions/cache": "6.0.1",
         "@actions/core": "3.0.1",
         "@actions/exec": "3.0.0",
         "@actions/github": "9.1.1",
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-6.1.0.tgz",
-      "integrity": "sha512-oRn9YhKkboXgIq2TQZ9uj6bhkT5ZUzFtnyTQ0tLGBwImaD0GfWShE5R0tPbN25EJmS3tz5sDd2JnVokAOtNrZQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-6.2.1.tgz",
+      "integrity": "sha512-sJGH0mhEbEjBCw7o6SaLhUU66u27aFW8HTfkIb5Tk2/Wy0caUDc+oYQEgnuFN7a0HCpAbQyK0U6U7XUJDgDWrw==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",
@@ -152,20 +152,20 @@
       "license": "ISC"
     },
     "node_modules/@actions/cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-6.0.0.tgz",
-      "integrity": "sha512-+tCs634SyGBQJ3KU1rtAVabmN/gYiT9WgzTSJzWwdPCLmM3zWrdbysaErKv8HyI6OozClrxNvDgPjJimbHZZvw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-6.0.1.tgz",
+      "integrity": "sha512-kcM23yPzDQEME05ZFV/bRzsHS9yDzCe97F7guF9+c/jJwE9ns+gFQt3MmnRXOHh1DsnlNuKcIwXYdnt4kHLGqg==",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^3.0.0",
+        "@actions/core": "^3.0.1",
         "@actions/exec": "^3.0.0",
         "@actions/glob": "^0.6.1",
-        "@actions/http-client": "^4.0.0",
-        "@actions/io": "^3.0.0",
-        "@azure/core-rest-pipeline": "^1.22.0",
-        "@azure/storage-blob": "^12.30.0",
+        "@actions/http-client": "^4.0.1",
+        "@actions/io": "^3.0.2",
+        "@azure/core-rest-pipeline": "^1.23.0",
+        "@azure/storage-blob": "^12.31.0",
         "@protobuf-ts/runtime-rpc": "^2.11.1",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       }
     },
     "node_modules/@actions/cache/node_modules/@actions/glob": {
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
@@ -513,7 +513,7 @@
         "@azure/core-tracing": "^1.3.0",
         "@azure/core-util": "^1.13.0",
         "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3175,9 +3175,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.2.tgz",
-      "integrity": "sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",

--- a/sources/package.json
+++ b/sources/package.json
@@ -35,8 +35,8 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@actions/artifact": "6.1.0",
-    "@actions/cache": "6.0.0",
+    "@actions/artifact": "6.2.1",
+    "@actions/cache": "6.0.1",
     "@actions/core": "3.0.1",
     "@actions/exec": "3.0.0",
     "@actions/github": "9.1.1",


### PR DESCRIPTION
## What

- Bumps `@actions/cache` 6.0.0 → 6.0.1
- Bumps `@actions/artifact` 6.1.0 → 6.2.1
- Removes the Dependabot `ignore` rules for both so they're maintained automatically going forward

## Why

Both deps were excluded from Dependabot's automatic updates: `*actions/cache*` was fully ignored, and `*actions/artifact*` had major/minor bumps ignored. Neither restriction is necessary.

The `cache` ignore existed out of concern for keeping versions aligned with the vendored `gradle-actions-caching` library. That alignment isn't required:

- The vendored bundle (`sources/vendor/gradle-actions-caching/index.js`) **inlines** its own (patched) `@actions/cache` and exposes a type-clean API (`restore`/`save`) that never leaks `@actions/cache` types across the boundary.
- This repo's own direct `@actions/cache` usage is a **separate, unpatched copy** consumed via the stock string-returning API (`cache-service-basic.ts`, `provision.ts`), with no `patch-package`/`postinstall` in this repo.

So there's no cross-repo sync requirement — these can be updated like any other dependency.

## Verification

- `npm install --package-lock-only` regenerated the lockfile (resolves cache 6.0.1, artifact 6.2.1)
- `./build` passes clean

The root `dist/` directory is intentionally left for the CI workflow to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)