### PR TITLE
Remove unnecessary dependency overrides

### DIFF
--- a/sources/package-lock.json
+++ b/sources/package-lock.json
@@ -92,6 +92,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@actions/artifact/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@actions/artifact/node_modules/@octokit/graphql": {
       "version": "9.0.3",
       "license": "MIT",
@@ -127,6 +140,35 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@actions/artifact/node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/artifact/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@actions/artifact/node_modules/before-after-hook": {
@@ -227,6 +269,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@actions/github/node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@actions/github/node_modules/@octokit/graphql": {
       "version": "9.0.3",
       "license": "MIT",
@@ -237,6 +292,21 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@actions/github/node_modules/@octokit/plugin-rest-endpoint-methods": {
@@ -250,6 +320,35 @@
       },
       "peerDependencies": {
         "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@actions/github/node_modules/before-after-hook": {
@@ -520,13 +619,16 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.1.4",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
       "license": "MIT",
       "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -1793,166 +1895,9 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "9.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/request": "^8.4.1",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
     "node_modules/@octokit/openapi-types": {
       "version": "27.0.0",
       "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "8.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^9.0.6",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "5.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/request/node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
-      }
     },
     "node_modules/@octokit/types": {
       "version": "16.0.0",
@@ -3210,11 +3155,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/binary": {
       "version": "0.3.0",
       "license": "MIT",
@@ -3640,6 +3580,19 @@
       "version": "0.0.1",
       "license": "MIT"
     },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
@@ -3847,10 +3800,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "license": "ISC"
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -6246,6 +6195,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "dev": true,
@@ -6803,6 +6758,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8385,10 +8341,6 @@
       "version": "1.0.6",
       "license": "MIT"
     },
-    "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "license": "ISC"
-    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -8714,6 +8666,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/sources/package.json
+++ b/sources/package.json
@@ -68,11 +68,5 @@
     "prettier": "3.8.4",
     "ts-jest": "29.4.11",
     "typescript": "5.9.3"
-  },
-  "overrides": {
-    "@azure/logger": "1.1.4",
-    "@octokit/request": "8.4.1",
-    "@octokit/request-error": "5.1.1",
-    "@octokit/plugin-paginate-rest": "9.2.2"
   }
 }

--- a/sources/package.json
+++ b/sources/package.json
@@ -73,12 +73,6 @@
     "@azure/logger": "1.1.4",
     "@octokit/request": "8.4.1",
     "@octokit/request-error": "5.1.1",
-    "@octokit/plugin-paginate-rest": "9.2.2",
-    "shell-quote": "1.8.4",
-    "fast-xml-parser": "5.8.0",
-    "fast-xml-builder": "1.2.0",
-    "eslint": {
-      "brace-expansion": "5.0.6"
-    }
+    "@octokit/plugin-paginate-rest": "9.2.2"
   }
 }


### PR DESCRIPTION
Removes all `overrides` from `sources/package.json`. Two commits, each independently verified:

## 1. Remove redundant security overrides

The `shell-quote`, `fast-xml-parser`, `fast-xml-builder` and `eslint > brace-expansion` overrides added in #980 are **no-ops**: npm's natural resolution already lands on the exact same patched versions, so they upgrade nothing. The vulnerabilities were actually resolved by regenerating the lockfile, not by the overrides.

## 2. Remove obsolete Octokit/Azure overrides

`@azure/logger`, `@octokit/request`, `@octokit/request-error` and `@octokit/plugin-paginate-rest` were point-in-time pins added to force-upgrade then-vulnerable transitive deps (5d947f45, #601). The parent packages (`@actions/github`, `@actions/artifact`) have since advanced and now resolve **newer, non-vulnerable** versions naturally — so the overrides only pinned stale versions:

| Package | Pinned (override) | Natural |
|---|---|---|
| `@octokit/request` | 8.4.1 | 10.0.10 |
| `@octokit/request-error` | 5.1.1 | 7.1.0 |
| `@octokit/plugin-paginate-rest` | 9.2.2 | 14.0.0 |
| `@azure/logger` | 1.1.4 | 1.3.0 |

## Verification

- `npm audit` → **0 vulnerabilities**
- `./build` → passes
- `npm test` → **352/352 passing**

### Note on a flaky test
While testing I saw the `wrapper-validation` test *"fetches wrapper jar checksums for snapshots"* intermittently fail (1–2 failures, then pass on retry). It is a **pre-existing flaky network test** — it makes ~175 live calls to Gradle services and sits right at its 60s timeout. Its code path imports neither Octokit nor Azure (`src/wrapper-validation/` uses only `@actions/http-client`/`nock`/`cheerio`), so it is unrelated to these overrides; the `nock`/`@mswjs/interceptors`/`undici` versions are identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)