### PR TITLE
Scope CI-integ-test concurrency groups per-branch

### DIFF
--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -28,9 +28,8 @@ jobs:
     needs: build-distribution
     uses: ./.github/workflows/suite-integ-test-caching.yml
     concurrency:
-      group: CI-integ-test-caching
+      group: CI-integ-test-caching-${{ github.ref }}
       cancel-in-progress: false
-      queue: max
     with:
       skip-dist: false
     secrets: inherit
@@ -41,9 +40,8 @@ jobs:
     needs: caching-integ-tests
     uses: ./.github/workflows/suite-integ-test-other.yml
     concurrency:
-      group: CI-integ-test-other
+      group: CI-integ-test-other-${{ github.ref }}
       cancel-in-progress: false
-      queue: max
     with:
       skip-dist: false
     secrets: inherit
@@ -54,9 +52,8 @@ jobs:
     needs: other-integ-tests
     uses: ./.github/workflows/suite-integ-test-dependency-submission.yml
     concurrency:
-      group: CI-integ-test-dependency-submission
+      group: CI-integ-test-dependency-submission-${{ github.ref }}
       cancel-in-progress: false
-      queue: max
     with:
       skip-dist: false
     secrets: inherit


### PR DESCRIPTION
## Problem

The `ci-integ-test.yml` workflow uses concurrency groups to limit parallel test runs. The groups used fixed names (`CI-integ-test-caching`, etc.) with no branch component, so **every** run across **every** branch shared a group. With `cancel-in-progress: false`, GitHub keeps one in-progress + one pending run per group and cancels the previously-pending run when a new one arrives — regardless of branch. The side effect: a push to `main` could cancel a pending PR run (and vice versa), leaving PRs not fully tested.

## Change

- Append `${{ github.ref }}` to each concurrency group. Runs now only supersede pending runs on the **same** branch; different branches get independent groups and run in parallel.
- Drop the `queue: max` key — it's not a valid GitHub Actions concurrency option (only `group` and `cancel-in-progress` are honored) and was being ignored.

## Behaviour after this change

- **Same branch**: a new run supersedes the pending run; the in-progress run finishes.
- **Different branches**: fully independent, run in parallel — `main` no longer disturbs a PR run.

Note: per-ref scoping means the `pull_request` and `push` events for a PR branch (different `github.ref`) won't dedupe against each other; this is intentional per the requested approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)