### PR TITLE
CI: add requireable aggregate/no-op checks for branch protection

### DIFF
--- a/.github/workflows/ci-init-script-check.yml
+++ b/.github/workflows/ci-init-script-check.yml
@@ -8,10 +8,6 @@ on:
     paths-ignore:
     - 'dist/**'
   pull_request:
-    paths:
-      - '.github/workflows/ci-init-script-check.yml'
-      - 'sources/src/resources/init-scripts/**'
-      - 'sources/test/init-scripts/**'
   workflow_dispatch:
 
 permissions:
@@ -23,16 +19,34 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+    # Detect whether anything relevant to the init-script tests changed.
+    # The workflow always runs (so it always reports a status check, making it safe
+    # to mark as required), but the heavy steps below are skipped on pull requests
+    # that don't touch the init-scripts. Pushes and manual runs always execute fully.
+    - name: Check for relevant changes
+      id: changes
+      if: github.event_name == 'pull_request'
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+      with:
+        files: |
+          .github/workflows/ci-init-script-check.yml
+          sources/src/resources/init-scripts/**
+          sources/test/init-scripts/**
     - name: Setup Java
+      if: steps.changes.outputs.any_changed == 'true' || github.event_name != 'pull_request'
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         distribution: temurin
         java-version: 17
     - name: Setup Gradle
+      if: steps.changes.outputs.any_changed == 'true' || github.event_name != 'pull_request'
       # Use a released version to avoid breakages
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       env:
         ALLOWED_GRADLE_WRAPPER_CHECKSUMS: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 # Invalid wrapper jar used for testing
     - name: Run integration tests
+      if: steps.changes.outputs.any_changed == 'true' || github.event_name != 'pull_request'
       working-directory: sources/test/init-scripts
       run: ./gradlew check

--- a/.github/workflows/ci-integ-test.yml
+++ b/.github/workflows/ci-integ-test.yml
@@ -57,3 +57,24 @@ jobs:
     with:
       skip-dist: false
     secrets: inherit
+
+  # Aggregate gate: a single check that succeeds only when all integ-test jobs succeed.
+  # Require this one check in branch protection instead of every fanned-out matrix job.
+  integ-test-success:
+    if: ${{ always() }}
+    needs:
+    - build-distribution
+    - caching-integ-tests
+    - other-integ-tests
+    - dependency-submission-integ-tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail if any integ-test job failed or was cancelled
+      if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      run: |
+        echo "One or more integ-test jobs did not succeed:"
+        echo "  build-distribution:                ${{ needs.build-distribution.result }}"
+        echo "  caching-integ-tests:               ${{ needs.caching-integ-tests.result }}"
+        echo "  other-integ-tests:                 ${{ needs.other-integ-tests.result }}"
+        echo "  dependency-submission-integ-tests: ${{ needs.dependency-submission-integ-tests.result }}"
+        exit 1


### PR DESCRIPTION
Prepares CI so a small, stable set of **required status checks** can be enabled (which in turn unlocks auto-merge), instead of having to list every fanned-out matrix job. GitHub required checks match by exact name — no wildcards — so this reduces the surface to a handful of high-level checks.

## Changes

- **`ci-integ-test.yml`**: add an aggregate gate job `integ-test-success` that `needs:` all four top-level jobs (the three suite jobs each wrap a reusable workflow that fans out into many nested checks) and fails if any did not succeed. `if: always()` ensures it reports even when a dependency fails. This collapses dozens of nested integ-test checks into a single requireable check.

- **`ci-init-script-check.yml`**: remove the workflow-level `pull_request.paths` filter so the workflow runs on every PR and always reports a status check (previously it was absent on most PRs, which would deadlock a required check). Relevant-change detection moves into the job via `tj-actions/changed-files` (same pinned action already used by `ci-check-no-dist-update.yml`). On a PR the Java/Gradle/test steps run only when init-script files changed; otherwise the job is a fast no-op that still succeeds. Push and `workflow_dispatch` runs execute fully as before.

## Suggested required-check set (all run on every PR, none can deadlock)

- `CI-check-and-unit-test / check-format-and-unit-test`
- `ci-validate-typings.yml / validate-typings`
- `CI-validate-wrappers / validation`
- `CI-codeql / Analyze (javascript-typescript)`
- `CI-integ-test / integ-test-success`
- `CI-init-script-check / test-init-scripts`

`ci-check-no-dist-update` is intentionally **omitted** — it only runs on `dist/**` edits and is designed to fail, so it shouldn't be a required gate.

> Confirm the exact check names from the list GitHub shows after this branch runs once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)