### PR TITLE
Render configuration-cache status in the caching Job Summary

### DIFF
--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -27,6 +27,8 @@ export type CacheCleanupStatus =
     | 'disabled-config-cache-hit'
     | 'disabled-readonly'
 
+export type ConfigurationCacheStatus = 'not-active' | 'restored' | 'not-restored' | 'restore-incomplete'
+
 export interface CacheEntryReport {
     entryName: string
     requestedKey?: string
@@ -47,6 +49,7 @@ export interface CacheEntryReport {
 export interface CacheReport {
     status: CacheStatus
     cleanup?: CacheCleanupStatus
+    configurationCache?: ConfigurationCacheStatus
     entries: CacheEntryReport[]
 }
 

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -1,4 +1,4 @@
-import {CacheCleanupStatus, CacheEntryReport, CacheReport, CacheStatus} from './cache-service'
+import {CacheCleanupStatus, CacheEntryReport, CacheReport, CacheStatus, ConfigurationCacheStatus} from './cache-service'
 
 const DOCS = 'https://github.com/gradle/actions/blob/main/docs/setup-gradle.md'
 const DISTRIBUTION = 'https://github.com/gradle/actions/blob/main/DISTRIBUTION.md'
@@ -26,6 +26,13 @@ const CLEANUP_COPY: Record<CacheCleanupStatus, string> = {
     'disabled-failure': `[Cache cleanup](${DOCS}#configuring-cache-cleanup) was skipped due to a build failure. Use \`cache-cleanup: always\` to override.`,
     'disabled-config-cache-hit': `[Cache cleanup](${DOCS}#configuring-cache-cleanup) was skipped due to configuration-cache reuse.`,
     'disabled-readonly': `[Cache cleanup](${DOCS}#configuring-cache-cleanup) is always disabled when the cache is read-only.`
+}
+
+const CONFIG_CACHE_COPY: Record<ConfigurationCacheStatus, string> = {
+    'not-active': `Configuration cache state was not cached — set a [cache-encryption-key](${DOCS}#cache-encryption-key) to enable configuration-cache caching.`,
+    restored: `Configuration cache state was restored from the cache.`,
+    'not-restored': `Configuration cache state was not restored — no cached data was available (e.g. the first run for this cache key).`,
+    'restore-incomplete': `Configuration cache state was not restored — the Gradle User Home was not fully restored.`
 }
 
 /**
@@ -69,6 +76,10 @@ function renderCleanupLine(cleanup?: CacheCleanupStatus): string | undefined {
     return cleanup ? CLEANUP_COPY[cleanup] : undefined
 }
 
+function renderConfigCacheLine(configurationCache?: ConfigurationCacheStatus): string | undefined {
+    return configurationCache ? CONFIG_CACHE_COPY[configurationCache] : undefined
+}
+
 function renderProviderNote(providerNote?: ProviderNote): string | undefined {
     if (!providerNote) {
         return undefined
@@ -88,9 +99,10 @@ function renderDetails(report: CacheReport): string {
         : `Entries: ${restored} restored, ${saved} saved - Expand for more details`
 
     const cleanup = report.status === 'enabled' ? renderCleanupLine(report.cleanup) : undefined
+    const configCache = renderConfigCacheLine(report.configurationCache)
     const table = renderEntryTable(report.entries)
     const pre = `<pre>\n${renderEntryDetails(report.entries)}</pre>`
-    const body = [STATUS_COPY[report.status], cleanup, table, pre].filter(Boolean).join('\n\n')
+    const body = [STATUS_COPY[report.status], cleanup, configCache, table, pre].filter(Boolean).join('\n\n')
 
     return `<details>
 <summary>${summary}</summary>

--- a/sources/test/jest/caching-report.test.ts
+++ b/sources/test/jest/caching-report.test.ts
@@ -79,6 +79,39 @@ describe('renderCachingReport', () => {
         expect(md).toContain('<summary>Entries: 1 restored, 0 saved - Expand for more details</summary>')
     })
 
+    it('renders the configuration-cache status line inside the details', () => {
+        const report: CacheReport = {
+            status: 'enabled',
+            cleanup: 'enabled',
+            configurationCache: 'restored',
+            entries: [entry()]
+        }
+        const md = renderCachingReport(report, ENHANCED)
+
+        const detailsBody = md.slice(md.indexOf('</summary>'))
+        expect(detailsBody).toContain('Configuration cache state was restored from the cache.')
+    })
+
+    it('explains an inactive configuration cache with a link to the encryption key docs', () => {
+        const report: CacheReport = {
+            status: 'enabled',
+            cleanup: 'enabled',
+            configurationCache: 'not-active',
+            entries: [entry()]
+        }
+        const md = renderCachingReport(report, ENHANCED)
+
+        expect(md).toContain('Configuration cache state was not cached')
+        expect(md).toContain('#cache-encryption-key')
+    })
+
+    it('omits the configuration-cache line when the status is absent', () => {
+        const report: CacheReport = {status: 'enabled', cleanup: 'enabled', entries: [entry()]}
+        const md = renderCachingReport(report, ENHANCED)
+
+        expect(md).not.toContain('Configuration cache state')
+    })
+
     it('renders a compact disabled report with no note and no details', () => {
         const report: CacheReport = {status: 'disabled', entries: []}
         const md = renderCachingReport(report, undefined)


### PR DESCRIPTION
Render the configuration-cache restore-state in the caching Job Summary, driven by the new `CacheReport.configurationCache` field produced by the `gradle-actions-caching` provider.

## What's here

- `cache-service.ts`: add a `ConfigurationCacheStatus` type (`not-active` / `restored` / `not-restored` / `restore-incomplete`) and an optional `configurationCache` field on `CacheReport`.
- `caching-report.ts`: a `CONFIG_CACHE_COPY` map and a prominent status line in `renderCachingReport`, beside the cleanup line. The `not-active` case links to the `#cache-encryption-key` docs.

## Cross-repo dependency

The field is populated by gradle/actions-caching PR #75 ("Restore configuration-cache support for simple builds"). This rendering compiles independently (it uses this repo's own `CacheReport` type) and renders nothing until the vendored `gradle-actions-caching` bundle is refreshed from that branch — so this should land with/after the vendor refresh.

## Verification

`npm run check` clean; full Jest suite (366 tests) passes, including 3 new rendering tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)