### PR TITLE
Support experimental project-entry caching (configuration-cache + build-logic)

### DIFF
--- a/sources/src/actions/dependency-submission/post.ts
+++ b/sources/src/actions/dependency-submission/post.ts
@@ -1,6 +1,6 @@
 import * as setupGradle from '../../setup-gradle'
 
-import {CacheConfig, SummaryConfig} from '../../configuration'
+import {CacheConfig, DevelocityConfig, SummaryConfig} from '../../configuration'
 import {handlePostActionError} from '../../errors'
 import {forceExit} from '../../force-exit'
 
@@ -14,7 +14,7 @@ process.on('uncaughtException', e => handlePostActionError(e))
  */
 export async function run(): Promise<void> {
     try {
-        await setupGradle.complete(new CacheConfig(), new SummaryConfig())
+        await setupGradle.complete(new CacheConfig(), new DevelocityConfig(), new SummaryConfig())
     } catch (error) {
         handlePostActionError(error)
     }

--- a/sources/src/actions/setup-gradle/post.ts
+++ b/sources/src/actions/setup-gradle/post.ts
@@ -1,7 +1,7 @@
 import * as setupGradle from '../../setup-gradle'
 import * as dependencyGraph from '../../dependency-graph'
 
-import {CacheConfig, DependencyGraphConfig, SummaryConfig} from '../../configuration'
+import {CacheConfig, DependencyGraphConfig, DevelocityConfig, SummaryConfig} from '../../configuration'
 import {handlePostActionError} from '../../errors'
 import {emitDeprecationWarnings, restoreDeprecationState} from '../../deprecation-collector'
 import {forceExit} from '../../force-exit'
@@ -19,7 +19,7 @@ export async function run(): Promise<void> {
         restoreDeprecationState()
         emitDeprecationWarnings()
 
-        if (await setupGradle.complete(new CacheConfig(), new SummaryConfig())) {
+        if (await setupGradle.complete(new CacheConfig(), new DevelocityConfig(), new SummaryConfig())) {
             // Only submit the dependency graphs once per job
             await dependencyGraph.complete(new DependencyGraphConfig())
         }

--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -8,6 +8,8 @@ export interface CacheOptions {
     strictMatch: boolean
     cleanup: string
     encryptionKey?: string
+    develocityAccessToken?: string
+    develocityServerUrl?: string
     includes: string[]
     excludes: string[]
 }
@@ -27,7 +29,18 @@ export type CacheCleanupStatus =
     | 'disabled-config-cache-hit'
     | 'disabled-readonly'
 
-export type ConfigurationCacheStatus = 'not-active' | 'restored' | 'not-restored' | 'restore-incomplete'
+// Mirrors ProjectCacheStatus in the gradle-actions-caching library. The first three are set on
+// restore (ungated); the rest on save, reflecting the opt-in + Develocity trial gate.
+export type ProjectCacheStatus =
+    | 'restore-incomplete'
+    | 'restored'
+    | 'not-restored'
+    | 'not-enabled'
+    | 'trial-expired'
+    | 'trial-not-licensed'
+    | 'not-stored-no-develocity-plugin'
+    | 'stored'
+    | 'stored-no-configuration-cache'
 
 export interface CacheEntryReport {
     entryName: string
@@ -49,7 +62,7 @@ export interface CacheEntryReport {
 export interface CacheReport {
     status: CacheStatus
     cleanup?: CacheCleanupStatus
-    configurationCache?: ConfigurationCacheStatus
+    projectCache?: ProjectCacheStatus
     entries: CacheEntryReport[]
 }
 

--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -29,18 +29,11 @@ export type CacheCleanupStatus =
     | 'disabled-config-cache-hit'
     | 'disabled-readonly'
 
-// Mirrors ProjectCacheStatus in the gradle-actions-caching library. The first three are set on
-// restore (ungated); the rest on save, reflecting the opt-in + Develocity trial gate.
 export type ProjectCacheStatus =
-    | 'restore-incomplete'
-    | 'restored'
-    | 'not-restored'
-    | 'not-enabled'
-    | 'trial-expired'
-    | 'trial-not-licensed'
-    | 'not-stored-no-develocity-plugin'
-    | 'stored'
-    | 'stored-no-configuration-cache'
+    | 'not-enabled' // the hidden opt-in env var was not set (rendered as nothing)
+    | 'trial-expired' // past the hard trial expiry
+    | 'trial-not-licensed' // Develocity trial token missing or invalid
+    | 'enabled' // Trial in effect: will attempt to save project state
 
 export interface CacheEntryReport {
     entryName: string

--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -33,6 +33,7 @@ export type ProjectCacheStatus =
     | 'not-enabled' // the hidden opt-in env var was not set (rendered as nothing)
     | 'trial-expired' // past the hard trial expiry
     | 'trial-not-licensed' // Develocity trial token missing or invalid
+    | 'no-encryption-key' // Cannot store due to missing encryption key
     | 'enabled' // Trial in effect: will attempt to save project state
 
 export interface CacheEntryReport {

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -29,18 +29,10 @@ const CLEANUP_COPY: Record<CacheCleanupStatus, string> = {
 }
 
 const PROJECT_CACHE_COPY: Record<ProjectCacheStatus, string> = {
-    // Restore (ungated).
-    'restore-incomplete': `Project state was not restored — the Gradle User Home was not fully restored.`,
-    restored: `Project state (build-logic and configuration cache) was restored from the cache.`,
-    'not-restored': `Project state was not restored — no cached data was available (e.g. the first run for this cache key).`,
-    // Save, Tier A gate. 'not-enabled' renders nothing (dropped by the .filter(Boolean) below).
     'not-enabled': ``,
-    'trial-expired': `Project state was not cached — the Develocity caching trial has expired.`,
-    'trial-not-licensed': `Project state was not cached — a valid Develocity trial token is required.`,
-    // Save, post-gate outcomes.
-    'not-stored-no-develocity-plugin': `Project state was not cached — applying the Develocity plugin is required to cache build-logic and configuration-cache state.`,
-    stored: `Project state (build-logic and configuration cache) was saved to the cache.`,
-    'stored-no-configuration-cache': `Build-logic state was cached. Storing configuration-cache data requires a build running Gradle >= 8.6 and a [valid encryption key](${DOCS}#cache-encryption-key).`
+    'trial-expired': `Project state (build-logic and configuration cache) was not cached — the Develocity caching trial has expired.`,
+    'trial-not-licensed': `Project state (build-logic and configuration cache) was not cached — a valid Develocity trial token is required.`,
+    'enabled': `Caching of project state (build-logic and configuration cache) was enabled.`
 }
 
 /**

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -30,8 +30,9 @@ const CLEANUP_COPY: Record<CacheCleanupStatus, string> = {
 
 const PROJECT_CACHE_COPY: Record<ProjectCacheStatus, string> = {
     'not-enabled': ``,
-    'trial-expired': `Project state (build-logic and configuration cache) was not cached — the Develocity caching trial has expired.`,
-    'trial-not-licensed': `Project state (build-logic and configuration cache) was not cached — a valid Develocity trial token is required.`,
+    'trial-expired': `Project state (build-logic and configuration cache) was not cached - the Develocity caching trial has expired.`,
+    'trial-not-licensed': `Project state (build-logic and configuration cache) was not cached - a develocity-access-key and develocity-server-url is required.`,
+    'no-encryption-key': `Project state (build-logic and configuration cache) was not cached - a [cache-encryption-key](${DOCS}#cache-encryption-key) is required.`,
     enabled: `Caching of project state (build-logic and configuration cache) was enabled.`
 }
 

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -32,7 +32,7 @@ const PROJECT_CACHE_COPY: Record<ProjectCacheStatus, string> = {
     'not-enabled': ``,
     'trial-expired': `Project state (build-logic and configuration cache) was not cached — the Develocity caching trial has expired.`,
     'trial-not-licensed': `Project state (build-logic and configuration cache) was not cached — a valid Develocity trial token is required.`,
-    'enabled': `Caching of project state (build-logic and configuration cache) was enabled.`
+    enabled: `Caching of project state (build-logic and configuration cache) was enabled.`
 }
 
 /**

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -1,4 +1,4 @@
-import {CacheCleanupStatus, CacheEntryReport, CacheReport, CacheStatus, ConfigurationCacheStatus} from './cache-service'
+import {CacheCleanupStatus, CacheEntryReport, CacheReport, CacheStatus, ProjectCacheStatus} from './cache-service'
 
 const DOCS = 'https://github.com/gradle/actions/blob/main/docs/setup-gradle.md'
 const DISTRIBUTION = 'https://github.com/gradle/actions/blob/main/DISTRIBUTION.md'
@@ -28,11 +28,19 @@ const CLEANUP_COPY: Record<CacheCleanupStatus, string> = {
     'disabled-readonly': `[Cache cleanup](${DOCS}#configuring-cache-cleanup) is always disabled when the cache is read-only.`
 }
 
-const CONFIG_CACHE_COPY: Record<ConfigurationCacheStatus, string> = {
-    'not-active': `Configuration cache state was not cached — set a [cache-encryption-key](${DOCS}#cache-encryption-key) to enable configuration-cache caching.`,
-    restored: `Configuration cache state was restored from the cache.`,
-    'not-restored': `Configuration cache state was not restored — no cached data was available (e.g. the first run for this cache key).`,
-    'restore-incomplete': `Configuration cache state was not restored — the Gradle User Home was not fully restored.`
+const PROJECT_CACHE_COPY: Record<ProjectCacheStatus, string> = {
+    // Restore (ungated).
+    'restore-incomplete': `Project state was not restored — the Gradle User Home was not fully restored.`,
+    restored: `Project state (build-logic and configuration cache) was restored from the cache.`,
+    'not-restored': `Project state was not restored — no cached data was available (e.g. the first run for this cache key).`,
+    // Save, Tier A gate. 'not-enabled' renders nothing (dropped by the .filter(Boolean) below).
+    'not-enabled': ``,
+    'trial-expired': `Project state was not cached — the Develocity caching trial has expired.`,
+    'trial-not-licensed': `Project state was not cached — a valid Develocity trial token is required.`,
+    // Save, post-gate outcomes.
+    'not-stored-no-develocity-plugin': `Project state was not cached — applying the Develocity plugin is required to cache build-logic and configuration-cache state.`,
+    stored: `Project state (build-logic and configuration cache) was saved to the cache.`,
+    'stored-no-configuration-cache': `Build-logic state was cached. Storing configuration-cache data requires a build running Gradle >= 8.6 and a [valid encryption key](${DOCS}#cache-encryption-key).`
 }
 
 /**
@@ -76,8 +84,9 @@ function renderCleanupLine(cleanup?: CacheCleanupStatus): string | undefined {
     return cleanup ? CLEANUP_COPY[cleanup] : undefined
 }
 
-function renderConfigCacheLine(configurationCache?: ConfigurationCacheStatus): string | undefined {
-    return configurationCache ? CONFIG_CACHE_COPY[configurationCache] : undefined
+function renderProjectCacheLine(projectCache?: ProjectCacheStatus): string | undefined {
+    // PROJECT_CACHE_COPY['not-enabled'] is '', which the .filter(Boolean) at the call site drops.
+    return projectCache ? PROJECT_CACHE_COPY[projectCache] : undefined
 }
 
 function renderProviderNote(providerNote?: ProviderNote): string | undefined {
@@ -99,10 +108,10 @@ function renderDetails(report: CacheReport): string {
         : `Entries: ${restored} restored, ${saved} saved - Expand for more details`
 
     const cleanup = report.status === 'enabled' ? renderCleanupLine(report.cleanup) : undefined
-    const configCache = renderConfigCacheLine(report.configurationCache)
+    const projectCache = renderProjectCacheLine(report.projectCache)
     const table = renderEntryTable(report.entries)
     const pre = `<pre>\n${renderEntryDetails(report.entries)}</pre>`
-    const body = [STATUS_COPY[report.status], cleanup, configCache, table, pre].filter(Boolean).join('\n\n')
+    const body = [STATUS_COPY[report.status], cleanup, projectCache, table, pre].filter(Boolean).join('\n\n')
 
     return `<details>
 <summary>${summary}</summary>

--- a/sources/src/develocity/build-scan.ts
+++ b/sources/src/develocity/build-scan.ts
@@ -1,8 +1,7 @@
 import * as core from '@actions/core'
 import {DevelocityConfig} from '../configuration'
-import {setupToken} from './short-lived-token'
 
-export async function setup(config: DevelocityConfig): Promise<void> {
+export function setup(config: DevelocityConfig): void {
     maybeExportVariable('DEVELOCITY_INJECTION_INIT_SCRIPT_NAME', 'gradle-actions.inject-develocity.init.gradle')
     maybeExportVariable('DEVELOCITY_INJECTION_CUSTOM_VALUE', 'gradle-actions')
 
@@ -39,12 +38,6 @@ export async function setup(config: DevelocityConfig): Promise<void> {
         maybeExportVariable('DEVELOCITY_INJECTION_TERMS_OF_USE_URL', config.getTermsOfUseUrl())
         maybeExportVariable('DEVELOCITY_INJECTION_TERMS_OF_USE_AGREE', config.getTermsOfUseAgree())
     }
-
-    return setupToken(
-        config.getDevelocityAccessKey(),
-        config.getDevelocityAllowUntrustedServer(),
-        config.getDevelocityTokenExpiry()
-    )
 }
 
 function maybeExportVariable(variableName: string, value: unknown): void {

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -174,3 +174,22 @@ export class DevelocityAccessCredentials {
         return this.accessKeyRegexp.test(allKeys)
     }
 }
+
+/**
+ * Resolve the access key that matches a given Develocity server, for use as the
+ * `develocityAccessToken` cache option. Returns `undefined` (fail-closed) when the access key is
+ * empty/malformed, the server URL is empty/unparseable, or no key matches the server's host.
+ */
+export function resolveAccessKeyForServer(accessKey: string, serverUrl: string): string | undefined {
+    const creds = DevelocityAccessCredentials.parse(accessKey)
+    if (!creds || !serverUrl) {
+        return undefined
+    }
+    let host: string
+    try {
+        host = new URL(serverUrl).hostname
+    } catch {
+        host = serverUrl // tolerate a bare hostname (no scheme)
+    }
+    return creds.keys.find(k => k.hostname === host)?.key
+}

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -178,11 +178,14 @@ export class DevelocityAccessCredentials {
 /**
  * Resolve the access key that matches a given Develocity server, for use as the
  * `develocityAccessToken` cache option. Returns `undefined` (fail-closed) when the access key is
- * empty/malformed, the server URL is empty/unparseable, or no key matches the server's host.
+ * empty, the server URL is empty/unparseable, or no entry matches the server's host.
+ *
+ * Parses the `host=value;host=value` form leniently rather than via `DevelocityAccessCredentials`:
+ * at save time the value is typically a short-lived token (a JWT whose `.`/`-` characters the strict
+ * parser rejects), but it is still a valid access token for that host.
  */
 export function resolveAccessKeyForServer(accessKey: string, serverUrl: string): string | undefined {
-    const creds = DevelocityAccessCredentials.parse(accessKey)
-    if (!creds || !serverUrl) {
+    if (!accessKey || !serverUrl) {
         return undefined
     }
     let host: string
@@ -191,5 +194,14 @@ export function resolveAccessKeyForServer(accessKey: string, serverUrl: string):
     } catch {
         host = serverUrl // tolerate a bare hostname (no scheme)
     }
-    return creds.keys.find(k => k.hostname === host)?.key
+    for (const entry of accessKey.split(';')) {
+        const sep = entry.indexOf('=')
+        if (sep < 1) {
+            continue // skip blanks / malformed entries with no `host=` prefix
+        }
+        if (entry.slice(0, sep) === host) {
+            return entry.slice(sep + 1) || undefined
+        }
+    }
+    return undefined
 }

--- a/sources/src/develocity/short-lived-token.ts
+++ b/sources/src/develocity/short-lived-token.ts
@@ -3,28 +3,41 @@ import * as httpm from '@actions/http-client'
 import {DevelocityConfig} from '../configuration'
 import {recordDeprecation} from '../deprecation-collector'
 
-export async function setupToken(
-    develocityAccessKey: string,
-    develocityAllowUntrustedServer: boolean | undefined,
-    develocityTokenExpiry: string
-): Promise<void> {
-    if (develocityAccessKey) {
-        try {
-            core.debug('Fetching short-lived token...')
-            const tokens = await getToken(develocityAccessKey, develocityAllowUntrustedServer, develocityTokenExpiry)
-            if (tokens != null && !tokens.isEmpty()) {
-                core.debug(`Got token(s), setting the access key env vars`)
-                const token = tokens.raw()
-                core.setSecret(token)
-                exportAccessKeyEnvVars(token)
-            } else {
-                handleMissingAccessToken()
-            }
-        } catch (e) {
-            handleMissingAccessToken()
-            core.warning(`Failed to fetch short-lived token, reason: ${e}`)
-        }
+/**
+ * Exchange the configured Develocity access key(s) for short-lived tokens, export them as the access
+ * key env vars, and return the short-lived token matching the configured Develocity server URL (for
+ * use as the `develocityAccessToken` cache option). Returns `undefined` when there is no access key,
+ * token fetching fails, or no token matches the configured server.
+ */
+export async function setupToken(config: DevelocityConfig): Promise<string | undefined> {
+    const develocityAccessKey = config.getDevelocityAccessKey()
+    if (!develocityAccessKey) {
+        return undefined
     }
+    try {
+        core.debug('Fetching short-lived token...')
+        const tokens = await getToken(
+            develocityAccessKey,
+            config.getDevelocityAllowUntrustedServer(),
+            config.getDevelocityTokenExpiry()
+        )
+        if (tokens != null && !tokens.isEmpty()) {
+            core.debug(`Got token(s), setting the access key env vars`)
+            const token = tokens.raw()
+            core.setSecret(token)
+            exportAccessKeyEnvVars(token)
+            for (const k of tokens.keys) {
+                core.setSecret(k.key)
+            }
+            const serverUrl = config.getDevelocityUrl()
+            return serverUrl ? resolveTokenForServer(tokens, serverUrl) : undefined
+        }
+        handleMissingAccessToken()
+    } catch (e) {
+        handleMissingAccessToken()
+        core.warning(`Failed to fetch short-lived token, reason: ${e}`)
+    }
+    return undefined
 }
 
 function exportAccessKeyEnvVars(value: string): void {
@@ -176,16 +189,11 @@ export class DevelocityAccessCredentials {
 }
 
 /**
- * Resolve the access key that matches a given Develocity server, for use as the
- * `develocityAccessToken` cache option. Returns `undefined` (fail-closed) when the access key is
- * empty, the server URL is empty/unparseable, or no entry matches the server's host.
- *
- * Parses the `host=value;host=value` form leniently rather than via `DevelocityAccessCredentials`:
- * at save time the value is typically a short-lived token (a JWT whose `.`/`-` characters the strict
- * parser rejects), but it is still a valid access token for that host.
+ * Resolve the token whose hostname matches a given Develocity server URL. Returns `undefined`
+ * (fail-closed) when the server URL is empty or no token matches the server's host.
  */
-export function resolveAccessKeyForServer(accessKey: string, serverUrl: string): string | undefined {
-    if (!accessKey || !serverUrl) {
+export function resolveTokenForServer(tokens: DevelocityAccessCredentials, serverUrl: string): string | undefined {
+    if (!serverUrl) {
         return undefined
     }
     let host: string
@@ -194,14 +202,5 @@ export function resolveAccessKeyForServer(accessKey: string, serverUrl: string):
     } catch {
         host = serverUrl // tolerate a bare hostname (no scheme)
     }
-    for (const entry of accessKey.split(';')) {
-        const sep = entry.indexOf('=')
-        if (sep < 1) {
-            continue // skip blanks / malformed entries with no `host=` prefix
-        }
-        if (entry.slice(0, sep) === host) {
-            return entry.slice(sep + 1) || undefined
-        }
-    }
-    return undefined
+    return tokens.keys.find(k => k.hostname === host)?.key
 }

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -13,6 +13,8 @@ export async function generateJobSummary(
     providerNote: ProviderNote | undefined,
     config: SummaryConfig
 ): Promise<void> {
+    core.startGroup('Generating Job Summary')
+
     const errors = renderErrors()
     if (errors) {
         core.summary.addRaw(errors)
@@ -23,19 +25,17 @@ export async function generateJobSummary(
     const summaryTable = renderSummaryTable(buildResults)
     const cachingReport = renderCachingReport(cacheReport, providerNote)
     const hasFailure = anyFailed(buildResults)
-    if (config.shouldGenerateJobSummary(hasFailure)) {
-        core.info('Generating Job Summary')
 
+    core.info(summaryTable)
+    core.info('============================')
+    core.info(cachingReport)
+
+    if (config.shouldGenerateJobSummary(hasFailure)) {
         core.summary.addRaw(summaryTable)
         core.summary.addRaw(cachingReport)
         await core.summary.write()
-    } else {
-        core.info('============================')
-        core.info(summaryTable)
-        core.info('============================')
-        core.info(cachingReport)
-        core.info('============================')
     }
+    core.endGroup()
 
     if (config.canAddPRComment()) {
         await minimizeObsoletePRComments()

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -5,6 +5,7 @@ import * as path from 'path'
 import * as os from 'os'
 import * as jobSummary from './job-summary'
 import * as buildScan from './develocity/build-scan'
+import {resolveAccessKeyForServer} from './develocity/short-lived-token'
 
 import {loadBuildResults, markBuildResultsProcessed} from './build-results'
 import {getCacheService, getProviderNote} from './cache-service-loader'
@@ -54,7 +55,11 @@ export async function setup(
     return true
 }
 
-export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryConfig): Promise<boolean> {
+export async function complete(
+    cacheConfig: CacheConfig,
+    develocityConfig: DevelocityConfig,
+    summaryConfig: SummaryConfig
+): Promise<boolean> {
     if (!core.getState(GRADLE_SETUP_VAR)) {
         core.info('Gradle setup post-action only performed for first gradle/actions step in workflow.')
         return false
@@ -65,7 +70,11 @@ export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryC
 
     const gradleUserHome = core.getState(GRADLE_USER_HOME)
     const cacheService = await getCacheService(cacheConfig)
-    const cacheReport = await cacheService.save(gradleUserHome, buildResults, cacheOptionsFrom(cacheConfig))
+    const cacheReport = await cacheService.save(
+        gradleUserHome,
+        buildResults,
+        cacheOptionsFrom(cacheConfig, develocityConfig)
+    )
     await jobSummary.generateJobSummary(buildResults, cacheReport, getProviderNote(cacheConfig), summaryConfig)
 
     markBuildResultsProcessed()
@@ -75,7 +84,14 @@ export async function complete(cacheConfig: CacheConfig, summaryConfig: SummaryC
     return true
 }
 
-function cacheOptionsFrom(config: CacheConfig): CacheOptions {
+function cacheOptionsFrom(config: CacheConfig, develocityConfig?: DevelocityConfig): CacheOptions {
+    // Trial credentials are threaded only on the save path (when develocityConfig is provided).
+    // On restore they stay undefined, which is fine: project-entry restore is ungated.
+    const develocityServerUrl = develocityConfig?.getDevelocityUrl() || undefined
+    const develocityAccessToken =
+        develocityConfig && develocityServerUrl
+            ? resolveAccessKeyForServer(develocityConfig.getDevelocityAccessKey(), develocityServerUrl)
+            : undefined
     return {
         disabled: config.isCacheDisabled(),
         readOnly: config.isCacheReadOnly(),
@@ -84,6 +100,8 @@ function cacheOptionsFrom(config: CacheConfig): CacheOptions {
         strictMatch: config.isCacheStrictMatch(),
         cleanup: config.getCacheCleanupOption(),
         encryptionKey: config.getCacheEncryptionKey() || undefined,
+        develocityAccessToken,
+        develocityServerUrl,
         includes: config.getCacheIncludes(),
         excludes: config.getCacheExcludes()
     }

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -46,7 +46,7 @@ export async function setup(
     initializeGradleUserHome(userHome, gradleUserHome, cacheConfig.getCacheEncryptionKey())
 
     const cacheService = await getCacheService(cacheConfig)
-    await cacheService.restore(gradleUserHome, cacheOptionsFrom(cacheConfig))
+    await cacheService.restore(gradleUserHome, cacheOptionsFrom(cacheConfig, develocityConfig))
 
     await wrapperValidator.validateWrappers(wrapperValidationConfig, getWorkspaceDirectory(), gradleUserHome)
 
@@ -84,9 +84,7 @@ export async function complete(
     return true
 }
 
-function cacheOptionsFrom(config: CacheConfig, develocityConfig?: DevelocityConfig): CacheOptions {
-    // Trial credentials are threaded only on the save path (when develocityConfig is provided).
-    // On restore they stay undefined, which is fine: project-entry restore is ungated.
+function cacheOptionsFrom(config: CacheConfig, develocityConfig: DevelocityConfig): CacheOptions {
     const develocityServerUrl = develocityConfig?.getDevelocityUrl() || undefined
     const develocityAccessToken =
         develocityConfig && develocityServerUrl

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import * as os from 'os'
 import * as jobSummary from './job-summary'
 import * as buildScan from './develocity/build-scan'
-import {resolveAccessKeyForServer} from './develocity/short-lived-token'
+import {setupToken} from './develocity/short-lived-token'
 
 import {loadBuildResults, markBuildResultsProcessed} from './build-results'
 import {getCacheService, getProviderNote} from './cache-service-loader'
@@ -22,6 +22,8 @@ import {initializeGradleUserHome} from './gradle-user-home'
 
 const GRADLE_SETUP_VAR = 'GRADLE_BUILD_ACTION_SETUP_COMPLETED'
 const GRADLE_USER_HOME = 'GRADLE_USER_HOME'
+// Short-lived Develocity token for the configured server, resolved during setup and reused on save.
+const DEVELOCITY_CACHE_TOKEN = 'DEVELOCITY_CACHE_TOKEN'
 
 export async function setup(
     cacheConfig: CacheConfig,
@@ -45,12 +47,18 @@ export async function setup(
 
     initializeGradleUserHome(userHome, gradleUserHome, cacheConfig.getCacheEncryptionKey())
 
+    // Exchange the long-lived access key(s) for short-lived tokens, resolving the token for the
+    // configured Develocity server and retaining it for the post-action (save) step.
+    const develocityServerUrl = develocityConfig.getDevelocityUrl() || undefined
+    const cacheToken = await setupToken(develocityConfig)
+    core.saveState(DEVELOCITY_CACHE_TOKEN, cacheToken ?? '')
+
     const cacheService = await getCacheService(cacheConfig)
-    await cacheService.restore(gradleUserHome, cacheOptionsFrom(cacheConfig, develocityConfig))
+    await cacheService.restore(gradleUserHome, cacheOptionsFrom(cacheConfig, develocityServerUrl, cacheToken))
 
     await wrapperValidator.validateWrappers(wrapperValidationConfig, getWorkspaceDirectory(), gradleUserHome)
 
-    await buildScan.setup(develocityConfig)
+    buildScan.setup(develocityConfig)
 
     return true
 }
@@ -69,11 +77,13 @@ export async function complete(
     const buildResults = loadBuildResults()
 
     const gradleUserHome = core.getState(GRADLE_USER_HOME)
+    const develocityServerUrl = develocityConfig.getDevelocityUrl() || undefined
+    const cacheToken = core.getState(DEVELOCITY_CACHE_TOKEN) || undefined
     const cacheService = await getCacheService(cacheConfig)
     const cacheReport = await cacheService.save(
         gradleUserHome,
         buildResults,
-        cacheOptionsFrom(cacheConfig, develocityConfig)
+        cacheOptionsFrom(cacheConfig, develocityServerUrl, cacheToken)
     )
     await jobSummary.generateJobSummary(buildResults, cacheReport, getProviderNote(cacheConfig), summaryConfig)
 
@@ -84,12 +94,11 @@ export async function complete(
     return true
 }
 
-function cacheOptionsFrom(config: CacheConfig, develocityConfig: DevelocityConfig): CacheOptions {
-    const develocityServerUrl = develocityConfig?.getDevelocityUrl() || undefined
-    const develocityAccessToken =
-        develocityConfig && develocityServerUrl
-            ? resolveAccessKeyForServer(develocityConfig.getDevelocityAccessKey(), develocityServerUrl)
-            : undefined
+function cacheOptionsFrom(
+    config: CacheConfig,
+    develocityServerUrl: string | undefined,
+    develocityAccessToken: string | undefined
+): CacheOptions {
     return {
         disabled: config.isCacheDisabled(),
         readOnly: config.isCacheReadOnly(),

--- a/sources/test/jest/caching-report.test.ts
+++ b/sources/test/jest/caching-report.test.ts
@@ -83,28 +83,15 @@ describe('renderCachingReport', () => {
         const report: CacheReport = {
             status: 'enabled',
             cleanup: 'enabled',
-            projectCache: 'restored',
+            projectCache: 'enabled',
             entries: [entry()]
         }
         const md = renderCachingReport(report, ENHANCED)
 
         const detailsBody = md.slice(md.indexOf('</summary>'))
         expect(detailsBody).toContain(
-            'Project state (build-logic and configuration cache) was restored from the cache.'
+            'Caching of project state (build-logic and configuration cache) was enabled.'
         )
-    })
-
-    it('explains an omitted configuration cache with a link to the encryption key docs', () => {
-        const report: CacheReport = {
-            status: 'enabled',
-            cleanup: 'enabled',
-            projectCache: 'stored-no-configuration-cache',
-            entries: [entry()]
-        }
-        const md = renderCachingReport(report, ENHANCED)
-
-        expect(md).toContain('Build-logic state was cached.')
-        expect(md).toContain('#cache-encryption-key')
     })
 
     it('renders nothing for the not-enabled project-cache status', () => {
@@ -117,7 +104,7 @@ describe('renderCachingReport', () => {
         const md = renderCachingReport(report, ENHANCED)
 
         expect(md).not.toContain('Project state')
-        expect(md).not.toContain('Build-logic state')
+        expect(md).not.toContain('build-logic')
     })
 
     it('omits the project-cache line when the status is absent', () => {

--- a/sources/test/jest/caching-report.test.ts
+++ b/sources/test/jest/caching-report.test.ts
@@ -79,37 +79,52 @@ describe('renderCachingReport', () => {
         expect(md).toContain('<summary>Entries: 1 restored, 0 saved - Expand for more details</summary>')
     })
 
-    it('renders the configuration-cache status line inside the details', () => {
+    it('renders the project-cache status line inside the details', () => {
         const report: CacheReport = {
             status: 'enabled',
             cleanup: 'enabled',
-            configurationCache: 'restored',
+            projectCache: 'restored',
             entries: [entry()]
         }
         const md = renderCachingReport(report, ENHANCED)
 
         const detailsBody = md.slice(md.indexOf('</summary>'))
-        expect(detailsBody).toContain('Configuration cache state was restored from the cache.')
+        expect(detailsBody).toContain(
+            'Project state (build-logic and configuration cache) was restored from the cache.'
+        )
     })
 
-    it('explains an inactive configuration cache with a link to the encryption key docs', () => {
+    it('explains an omitted configuration cache with a link to the encryption key docs', () => {
         const report: CacheReport = {
             status: 'enabled',
             cleanup: 'enabled',
-            configurationCache: 'not-active',
+            projectCache: 'stored-no-configuration-cache',
             entries: [entry()]
         }
         const md = renderCachingReport(report, ENHANCED)
 
-        expect(md).toContain('Configuration cache state was not cached')
+        expect(md).toContain('Build-logic state was cached.')
         expect(md).toContain('#cache-encryption-key')
     })
 
-    it('omits the configuration-cache line when the status is absent', () => {
+    it('renders nothing for the not-enabled project-cache status', () => {
+        const report: CacheReport = {
+            status: 'enabled',
+            cleanup: 'enabled',
+            projectCache: 'not-enabled',
+            entries: [entry()]
+        }
+        const md = renderCachingReport(report, ENHANCED)
+
+        expect(md).not.toContain('Project state')
+        expect(md).not.toContain('Build-logic state')
+    })
+
+    it('omits the project-cache line when the status is absent', () => {
         const report: CacheReport = {status: 'enabled', cleanup: 'enabled', entries: [entry()]}
         const md = renderCachingReport(report, ENHANCED)
 
-        expect(md).not.toContain('Configuration cache state')
+        expect(md).not.toContain('Project state')
     })
 
     it('renders a compact disabled report with no note and no details', () => {

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -1,7 +1,7 @@
 import nock from "nock";
 import {describe, expect, it} from '@jest/globals'
 
-import {DevelocityAccessCredentials, getToken} from "../../src/develocity/short-lived-token";
+import {DevelocityAccessCredentials, getToken, resolveAccessKeyForServer} from "../../src/develocity/short-lived-token";
 
 describe('short lived tokens', () => {
     it('parse valid access key should return an object', async () => {
@@ -132,5 +132,39 @@ describe('short lived tokens with retry', () => {
         await expect(getToken('dev=xyz', false, ''))
             .resolves
             .toBeNull()
+    })
+})
+
+describe('resolveAccessKeyForServer', () => {
+    it('returns the key matching the server host from a full URL', () => {
+        expect(resolveAccessKeyForServer('ge.example.com=key1;other=key2', 'https://ge.example.com')).toBe('key1')
+    })
+
+    it('matches on hostname, ignoring scheme, port and path', () => {
+        expect(resolveAccessKeyForServer('ge.example.com=key1', 'https://ge.example.com:8443/path')).toBe('key1')
+    })
+
+    it('tolerates a bare hostname with no scheme', () => {
+        expect(resolveAccessKeyForServer('ge.example.com=key1', 'ge.example.com')).toBe('key1')
+    })
+
+    it('selects the matching key when multiple are present', () => {
+        expect(resolveAccessKeyForServer('dev=key1;ge.example.com=key2', 'https://ge.example.com')).toBe('key2')
+    })
+
+    it('returns undefined when no key matches the server host', () => {
+        expect(resolveAccessKeyForServer('ge.example.com=key1', 'https://other.example.com')).toBeUndefined()
+    })
+
+    it('returns undefined for an empty server URL', () => {
+        expect(resolveAccessKeyForServer('ge.example.com=key1', '')).toBeUndefined()
+    })
+
+    it('returns undefined for an empty access key', () => {
+        expect(resolveAccessKeyForServer('', 'https://ge.example.com')).toBeUndefined()
+    })
+
+    it('returns undefined for a malformed access key', () => {
+        expect(resolveAccessKeyForServer('not-a-valid-access-key', 'https://ge.example.com')).toBeUndefined()
     })
 })

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -152,6 +152,11 @@ describe('resolveAccessKeyForServer', () => {
         expect(resolveAccessKeyForServer('dev=key1;ge.example.com=key2', 'https://ge.example.com')).toBe('key2')
     })
 
+    it('accepts a short-lived token value (JWT with dots and dashes)', () => {
+        const token = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ4In0.sig-na_ture'
+        expect(resolveAccessKeyForServer(`ge.example.com=${token}`, 'https://ge.example.com')).toBe(token)
+    })
+
     it('returns undefined when no key matches the server host', () => {
         expect(resolveAccessKeyForServer('ge.example.com=key1', 'https://other.example.com')).toBeUndefined()
     })

--- a/sources/test/jest/short-lived-token.test.ts
+++ b/sources/test/jest/short-lived-token.test.ts
@@ -1,7 +1,7 @@
 import nock from "nock";
 import {describe, expect, it} from '@jest/globals'
 
-import {DevelocityAccessCredentials, getToken, resolveAccessKeyForServer} from "../../src/develocity/short-lived-token";
+import {DevelocityAccessCredentials, getToken, resolveTokenForServer} from "../../src/develocity/short-lived-token";
 
 describe('short lived tokens', () => {
     it('parse valid access key should return an object', async () => {
@@ -135,41 +135,41 @@ describe('short lived tokens with retry', () => {
     })
 })
 
-describe('resolveAccessKeyForServer', () => {
-    it('returns the key matching the server host from a full URL', () => {
-        expect(resolveAccessKeyForServer('ge.example.com=key1;other=key2', 'https://ge.example.com')).toBe('key1')
+describe('resolveTokenForServer', () => {
+    const credentials = (...pairs: [string, string][]): DevelocityAccessCredentials =>
+        DevelocityAccessCredentials.of(pairs.map(([hostname, key]) => ({hostname, key})))
+
+    it('returns the token matching the server host from a full URL', () => {
+        const tokens = credentials(['ge.example.com', 'key1'], ['other', 'key2'])
+        expect(resolveTokenForServer(tokens, 'https://ge.example.com')).toBe('key1')
     })
 
     it('matches on hostname, ignoring scheme, port and path', () => {
-        expect(resolveAccessKeyForServer('ge.example.com=key1', 'https://ge.example.com:8443/path')).toBe('key1')
+        const tokens = credentials(['ge.example.com', 'key1'])
+        expect(resolveTokenForServer(tokens, 'https://ge.example.com:8443/path')).toBe('key1')
     })
 
     it('tolerates a bare hostname with no scheme', () => {
-        expect(resolveAccessKeyForServer('ge.example.com=key1', 'ge.example.com')).toBe('key1')
+        const tokens = credentials(['ge.example.com', 'key1'])
+        expect(resolveTokenForServer(tokens, 'ge.example.com')).toBe('key1')
     })
 
-    it('selects the matching key when multiple are present', () => {
-        expect(resolveAccessKeyForServer('dev=key1;ge.example.com=key2', 'https://ge.example.com')).toBe('key2')
+    it('selects the matching token when multiple are present', () => {
+        const tokens = credentials(['dev', 'key1'], ['ge.example.com', 'key2'])
+        expect(resolveTokenForServer(tokens, 'https://ge.example.com')).toBe('key2')
     })
 
-    it('accepts a short-lived token value (JWT with dots and dashes)', () => {
-        const token = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ4In0.sig-na_ture'
-        expect(resolveAccessKeyForServer(`ge.example.com=${token}`, 'https://ge.example.com')).toBe(token)
-    })
-
-    it('returns undefined when no key matches the server host', () => {
-        expect(resolveAccessKeyForServer('ge.example.com=key1', 'https://other.example.com')).toBeUndefined()
+    it('returns undefined when no token matches the server host', () => {
+        const tokens = credentials(['ge.example.com', 'key1'])
+        expect(resolveTokenForServer(tokens, 'https://other.example.com')).toBeUndefined()
     })
 
     it('returns undefined for an empty server URL', () => {
-        expect(resolveAccessKeyForServer('ge.example.com=key1', '')).toBeUndefined()
+        const tokens = credentials(['ge.example.com', 'key1'])
+        expect(resolveTokenForServer(tokens, '')).toBeUndefined()
     })
 
-    it('returns undefined for an empty access key', () => {
-        expect(resolveAccessKeyForServer('', 'https://ge.example.com')).toBeUndefined()
-    })
-
-    it('returns undefined for a malformed access key', () => {
-        expect(resolveAccessKeyForServer('not-a-valid-access-key', 'https://ge.example.com')).toBeUndefined()
+    it('returns undefined when there are no tokens', () => {
+        expect(resolveTokenForServer(credentials(), 'https://ge.example.com')).toBeUndefined()
     })
 })


### PR DESCRIPTION
Pass develocityAccessToken and develocityServerUrl the `gradle-actions-caching`: required to support project-entry caching (build-logic + configuration-cache), which has experimental support in 'gradle-actions-cache@v0.8.0. This support is not yet released and will be available as a restricted trial.
