### PR TITLE
Disable Isolated Projects via promoted property in dependency-submission

### DIFF
--- a/sources/src/actions/dependency-submission/main.ts
+++ b/sources/src/actions/dependency-submission/main.ts
@@ -47,6 +47,7 @@ export async function run(): Promise<void> {
               -Dorg.gradle.configureondemand=false
               -Dorg.gradle.dependency.verification=off
               -Dorg.gradle.unsafe.isolated-projects=false
+              -Dorg.gradle.isolated-projects=false
               ${taskList}
               ${additionalArgs}
         `


### PR DESCRIPTION
## Problem

The `dependency-submission` action disables Isolated Projects for the dependency-resolution build by passing `-Dorg.gradle.unsafe.isolated-projects=false`.

Recent Gradle versions have promoted the property to `org.gradle.isolated-projects`. A build that enables IP via the promoted property (e.g. `gradle/gradle`, see [this failing run](https://github.com/gradle/gradle/actions/runs/30357651750/job/90269499556?pr=38402)) is no longer disabled by the unsafe spelling, so the build runs with IP enabled and fails:

```
Error resolving plugin [id: 'gradlebuild.build-environment']
> Project ':build-logic-settings' cannot access 'Project.tasks' functionality on subprojects via 'allprojects'
```

(`ForceDependencyResolutionPlugin` is not IP-compatible.)

## Fix

Pass both spellings of the property. `-D` system properties that Gradle does not recognize are silently ignored, so this is safe for all supported Gradle versions — the action already passes the unsafe spelling to pre-IP Gradle versions without issue.