### PR TITLE
Run pre-existing-gradle-home smoke test on Linux only

### DIFF
--- a/.github/workflows/smoke-test-restore-gradle-home.yml
+++ b/.github/workflows/smoke-test-restore-gradle-home.yml
@@ -114,15 +114,16 @@ jobs:
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test
 
-  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache
+  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache.
+  #
+  # Deliberately not run against the 'runner-os' matrix: creating ~/.gradle up-front is precisely
+  # what stops setup-gradle relocating the Gradle User Home to D:\a\.gradle on Windows, so this job
+  # would look for a cache entry rooted at a different path than the one the seed build saved.
+  # Cache entries are identified by key *and* by a version derived from the cache paths, so that
+  # never matches. This is integration-level behaviour rather than a smoke test, so run it on Linux.
   restore-gradle-home-pre-existing-gradle-home:
     needs: restore-gradle-home-seed-build
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        os: ${{fromJSON(inputs.runner-os)}}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
`restore-gradle-home-pre-existing-gradle-home (windows-latest)` was the last job still failing in [run 30724918566](https://github.com/gradle/actions/actions/runs/30724918566), which tests the unreleased `gradle-actions-caching` Windows fix. The failure is a test artifact, not a caching bug.

## Diagnosis

The job requests a cache key **byte-identical** to the one the seed build saved and still gets `(Entry not restored: no match found)` — while `restore-gradle-home-dependencies-cache (windows-latest)` restored that exact key six seconds earlier in the same run.

The difference is the Gradle User Home:

| job | Gradle User Home | result |
|---|---|---|
| seed (win) | `D:\a\.gradle` | saved 7 entries |
| dependencies-cache (win) | `D:\a\.gradle` | ✅ cache hit |
| **pre-existing (win)** | **`C:\Users\runneradmin\.gradle`** | ❌ no match |
| pre-existing (ubuntu) | `/home/runner/.gradle` | ✅ 7 restored |

The test's own `mkdir -p ~/.gradle/caches` causes it. `determineGradleUserHome()` (`sources/src/setup-gradle.ts:117-142`) only relocates to the faster D: drive when `~/.gradle` does **not** already exist, so pre-creating it pins the Gradle User Home to `C:`.

That matters because a cache entry is identified by *(key, version)*, and the version is a hash of the cache paths — see `getCacheVersion()` in `@actions/cache/lib/internal/cacheUtils.js`. Different Gradle User Home → different paths → different version → guaranteed miss, however identical the key looks in the logs. The build then runs against an empty Gradle User Home and `--offline` fails resolving `com.gradle.develocity`.

The ubuntu leg is the control: same pre-create, same `cache-overwrite-existing: true`, but no relocation on Linux, so the paths match. That rules out `cache-overwrite-existing` and the library fix as causes.

## Change

Run this one job on `ubuntu-latest` instead of the `runner-os` matrix. Testing Gradle User Home relocation semantics is integration-level rather than smoke-level behaviour. The other four jobs in the workflow keep their Windows coverage.

## Note

Separately, this is a real sharp edge in the product: on Windows the Gradle User Home location depends on whether `~/.gradle` happens to exist when `setup-gradle` runs. If something creates it in one job but not another, the user gets a silent cache miss whose logs show a correct-looking key and no hint at the cause. Possibly worth a warning in `gradle-actions-caching`, but that is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)