### PR TITLE
Move non-smoke restore-gradle-home tests back to the integ-test suite

### DIFF
--- a/.github/workflows/integ-test-restore-gradle-home.yml
+++ b/.github/workflows/integ-test-restore-gradle-home.yml
@@ -1,0 +1,134 @@
+name: Test restore Gradle Home
+
+on:
+  workflow_call:
+    inputs:
+      cache-key-prefix:
+        type: string
+        default: '0'
+      runner-os:
+        type: string
+        default: '["ubuntu-latest"]'
+      skip-dist:
+        type: boolean
+        default: false
+
+env:
+  SKIP_DIST: ${{ inputs.skip-dist }}
+  GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-gradle-home-${{ inputs.cache-key-prefix }}
+  GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-gradle-home
+
+permissions:
+  contents: read
+
+jobs:
+  restore-gradle-home-seed-build:
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: ${{fromJSON(inputs.runner-os)}}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Initialize integ-test
+      uses: ./.github/actions/init-integ-test
+
+    - name: Setup Gradle
+      uses: ./setup-gradle
+      with:
+        cache-read-only: false # For testing, allow writing cache entries on non-default branches
+    - name: Build using Gradle wrapper
+      working-directory: .github/workflow-samples/groovy-dsl
+      run: ./gradlew test
+
+  # Test that the gradle-user-home cache will cache and restore local build-cache
+  restore-gradle-home-build-cache:
+    needs: restore-gradle-home-seed-build
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: ${{fromJSON(inputs.runner-os)}}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Initialize integ-test
+      uses: ./.github/actions/init-integ-test
+
+    - name: Setup Gradle
+      uses: ./setup-gradle
+      with:
+        cache-read-only: true
+    - name: Execute Gradle build and verify tasks from cache
+      working-directory: .github/workflow-samples/groovy-dsl
+      run: ./gradlew test -DverifyCachedBuild=true
+
+  # Check that the build can run when Gradle User Home is not fully restored
+  restore-gradle-home-no-extracted-cache-entries-restored:
+    needs: restore-gradle-home-seed-build
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: ${{fromJSON(inputs.runner-os)}}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Initialize integ-test
+      uses: ./.github/actions/init-integ-test
+
+    - name: Setup Gradle with no extracted cache entries restored
+      uses: ./setup-gradle
+      env: 
+        GRADLE_BUILD_ACTION_SKIP_RESTORE: "generated-gradle-jars|wrapper-zips|java-toolchains|instrumented-jars|dependencies|kotlin-dsl"
+      with:
+        cache-read-only: true
+    - name: Check executee Gradle build
+      working-directory: .github/workflow-samples/groovy-dsl
+      run: ./gradlew test
+
+  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache.
+  #
+  # Deliberately not run against the 'runner-os' matrix: creating ~/.gradle up-front is precisely
+  # what stops setup-gradle relocating the Gradle User Home to D:\a\.gradle on Windows, so this job
+  # would look for a cache entry rooted at a different path than the one the seed build saved.
+  # Cache entries are identified by key *and* by a version derived from the cache paths, so that
+  # never matches.
+  restore-gradle-home-pre-existing-gradle-home:
+    needs: restore-gradle-home-seed-build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Initialize integ-test
+      uses: ./.github/actions/init-integ-test
+
+    - name: Pre-create Gradle User Home
+      shell: bash
+      run: |
+        mkdir -p ~/.gradle/caches
+        touch ~/.gradle/gradle.properties
+        touch ~/.gradle/caches/dummy.txt
+    - name: Setup Gradle
+      uses: ./setup-gradle
+      with:
+        cache-read-only: true
+        cache-overwrite-existing: true
+    - name: Check that pre-existing content still exists
+      shell: bash
+      run: |
+        if [ ! -e ~/.gradle/caches/dummy.txt ]; then
+          echo "::error ::Should find dummy.txt after cache restore"
+          exit 1
+        fi
+        if [ ! -e ~/.gradle/gradle.properties ]; then
+          echo "::error ::Should find gradle.properties after cache restore"
+          exit 1
+        fi
+    - name: Execute Gradle build with --offline
+      working-directory: .github/workflow-samples/groovy-dsl
+      run: ./gradlew test --offline

--- a/.github/workflows/smoke-test-restore-gradle-home.yml
+++ b/.github/workflows/smoke-test-restore-gradle-home.yml
@@ -1,4 +1,4 @@
-name: Test restore Gradle Home
+name: Smoke test restore Gradle Home
 
 on:
   workflow_call:
@@ -15,8 +15,10 @@ on:
 
 env:
   SKIP_DIST: ${{ inputs.skip-dist }}
-  GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: restore-gradle-home-${{ inputs.cache-key-prefix }}
-  GRADLE_BUILD_ACTION_CACHE_KEY_JOB: restore-gradle-home
+  # Distinct from the keys used by integ-test-restore-gradle-home.yml, which seeds an equivalent
+  # cache entry. Both suites run concurrently, so they must not write to the same cache key.
+  GRADLE_BUILD_ACTION_CACHE_KEY_PREFIX: smoke-test-restore-gradle-home-${{ inputs.cache-key-prefix }}
+  GRADLE_BUILD_ACTION_CACHE_KEY_JOB: smoke-test-restore-gradle-home
 
 permissions:
   contents: read
@@ -62,96 +64,6 @@ jobs:
       uses: ./setup-gradle
       with:
         cache-read-only: true
-    - name: Execute Gradle build with --offline
-      working-directory: .github/workflow-samples/groovy-dsl
-      run: ./gradlew test --offline
-
-  # Test that the gradle-user-home cache will cache and restore local build-cache
-  restore-gradle-home-build-cache:
-    needs: restore-gradle-home-seed-build
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        os: ${{fromJSON(inputs.runner-os)}}
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - name: Initialize integ-test
-      uses: ./.github/actions/init-integ-test
-
-    - name: Setup Gradle
-      uses: ./setup-gradle
-      with:
-        cache-read-only: true
-    - name: Execute Gradle build and verify tasks from cache
-      working-directory: .github/workflow-samples/groovy-dsl
-      run: ./gradlew test -DverifyCachedBuild=true
-
-  # Check that the build can run when Gradle User Home is not fully restored
-  restore-gradle-home-no-extracted-cache-entries-restored:
-    needs: restore-gradle-home-seed-build
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        os: ${{fromJSON(inputs.runner-os)}}
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - name: Initialize integ-test
-      uses: ./.github/actions/init-integ-test
-
-    - name: Setup Gradle with no extracted cache entries restored
-      uses: ./setup-gradle
-      env: 
-        GRADLE_BUILD_ACTION_SKIP_RESTORE: "generated-gradle-jars|wrapper-zips|java-toolchains|instrumented-jars|dependencies|kotlin-dsl"
-      with:
-        cache-read-only: true
-    - name: Check executee Gradle build
-      working-directory: .github/workflow-samples/groovy-dsl
-      run: ./gradlew test
-
-  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache.
-  #
-  # Deliberately not run against the 'runner-os' matrix: creating ~/.gradle up-front is precisely
-  # what stops setup-gradle relocating the Gradle User Home to D:\a\.gradle on Windows, so this job
-  # would look for a cache entry rooted at a different path than the one the seed build saved.
-  # Cache entries are identified by key *and* by a version derived from the cache paths, so that
-  # never matches. This is integration-level behaviour rather than a smoke test, so run it on Linux.
-  restore-gradle-home-pre-existing-gradle-home:
-    needs: restore-gradle-home-seed-build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - name: Initialize integ-test
-      uses: ./.github/actions/init-integ-test
-
-    - name: Pre-create Gradle User Home
-      shell: bash
-      run: |
-        mkdir -p ~/.gradle/caches
-        touch ~/.gradle/gradle.properties
-        touch ~/.gradle/caches/dummy.txt
-    - name: Setup Gradle
-      uses: ./setup-gradle
-      with:
-        cache-read-only: true
-        cache-overwrite-existing: true
-    - name: Check that pre-existing content still exists
-      shell: bash
-      run: |
-        if [ ! -e ~/.gradle/caches/dummy.txt ]; then
-          echo "::error ::Should find dummy.txt after cache restore"
-          exit 1
-        fi
-        if [ ! -e ~/.gradle/gradle.properties ]; then
-          echo "::error ::Should find gradle.properties after cache restore"
-          exit 1
-        fi
     - name: Execute Gradle build with --offline
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test --offline

--- a/.github/workflows/smoke-test-restore-gradle-home.yml
+++ b/.github/workflows/smoke-test-restore-gradle-home.yml
@@ -114,15 +114,16 @@ jobs:
       working-directory: .github/workflow-samples/groovy-dsl
       run: ./gradlew test
 
-  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache
+  # Test that a pre-existing gradle-user-home can be overwritten by the restored cache.
+  #
+  # Deliberately not run against the 'runner-os' matrix: creating ~/.gradle up-front is precisely
+  # what stops setup-gradle relocating the Gradle User Home to D:\a\.gradle on Windows, so this job
+  # would look for a cache entry rooted at a different path than the one the seed build saved.
+  # Cache entries are identified by key *and* by a version derived from the cache paths, so that
+  # never matches. This is integration-level behaviour rather than a smoke test, so run it on Linux.
   restore-gradle-home-pre-existing-gradle-home:
     needs: restore-gradle-home-seed-build
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        os: ${{fromJSON(inputs.runner-os)}}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/suite-integ-test-caching.yml
+++ b/.github/workflows/suite-integ-test-caching.yml
@@ -36,6 +36,11 @@ jobs:
     with:
       skip-dist: ${{ inputs.skip-dist }}
 
+  restore-gradle-home:
+    uses: ./.github/workflows/integ-test-restore-gradle-home.yml
+    with:
+      skip-dist: ${{ inputs.skip-dist }}
+
   restore-java-toolchain:
     uses: ./.github/workflows/integ-test-restore-java-toolchain.yml
     with:


### PR DESCRIPTION
Partial revert of the extraction in #1027. The caching smoke test should answer one question quickly — does a seeded cache let a later build run `--offline`? Everything else is integration-level.

**Supersedes #1030**, whose commit is included here. Close it, or merge it first and this merges cleanly on top.

## Layout

`smoke-test-restore-gradle-home.yml` — two jobs:

| job | purpose |
|---|---|
| `restore-gradle-home-seed-build` | seed the cache |
| `restore-gradle-home-dependencies-cache` | verify the restored cache allows `--offline` |

`integ-test-restore-gradle-home.yml` — restored, wired back into `suite-integ-test-caching`:

| job | purpose |
|---|---|
| `restore-gradle-home-seed-build` | seed the cache (duplicated, see below) |
| `restore-gradle-home-build-cache` | local build-cache restored |
| `restore-gradle-home-no-extracted-cache-entries-restored` | build works with cache entries skipped |
| `restore-gradle-home-pre-existing-gradle-home` | pre-existing GUH overwritten by restore |

## Notes

**The seed job is duplicated, with distinct cache keys.** The smoke suite now uses `smoke-test-restore-gradle-home-*`; the integ suite keeps `restore-gradle-home-*`. This matters: `smoke-tests` and `caching-integ-tests` run concurrently in `ci-integ-test.yml`, so sharing a key would have both suites racing to write the same entry.

**Distinct workflow `name:`.** The smoke workflow is now `Smoke test restore Gradle Home`, so the two don't show up identically in the Actions UI.

**`pre-existing-gradle-home` stays pinned to `ubuntu-latest`**, with the reason recorded in a comment — pre-creating `~/.gradle` is exactly what stops `setup-gradle` relocating the Gradle User Home to `D:\a\.gradle` on Windows, so the job would look for a cache entry rooted at a different path than the seed build saved. Cache entries are identified by key *and* by a version derived from the cache paths, so that can never match. The integ suite runs ubuntu-only by default anyway; the pin keeps it correct if a matrix is ever passed.

## Verification

All workflow YAML parses, and every local `uses:` reference resolves — no dangling paths after the rename and re-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)