### PR TITLE
setup-gradle: attribute a disabled cache to an external caching provider in the Job Summary

### DIFF
--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -153,6 +153,27 @@ Caching is enabled by default. You can disable caching for the action as follows
 cache-disabled: true
 ```
 
+#### Reporting an external caching provider
+
+When you disable caching because another action in the workflow provides dependency
+caching (for example, the Develocity Artifact Cache action), that action can advertise
+itself so the Job Summary attributes the disabled Gradle User Home cache to it instead of
+reporting a bare "caching was disabled". To do so, the other action exports the
+`GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER` environment variable with a display label:
+
+```yaml
+# Exported by the co-resident caching action, not something you normally set by hand:
+GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER: Develocity Artifact Cache
+```
+
+When this variable is set and `setup-gradle`'s own caching is disabled, the caching
+section of the Job Summary reads "handled externally by _&lt;label&gt;_" rather than
+"caching was disabled". It has no effect when `setup-gradle`'s caching is active.
+
+> [!NOTE]
+> `GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER` is the integration point between `setup-gradle`
+> and a co-resident caching action. Its name and contract are still being finalized.
+
 #### Using the cache read-only
 
 By default, The `setup-gradle` action will only write to the cache from Jobs on the default (`main`/`master`) branch.

--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -167,12 +167,35 @@ GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER: Develocity Artifact Cache
 ```
 
 When this variable is set and `setup-gradle`'s own caching is disabled, the caching
-section of the Job Summary reads "handled externally by _&lt;label&gt;_" rather than
-"caching was disabled". It has no effect when `setup-gradle`'s caching is active.
+section of the Job Summary attributes the disabled cache to that action rather than
+reporting a bare "caching was disabled". It still reports that `setup-gradle`'s caching is
+disabled — the variable changes the attribution, not the fact.
+
+When the variable is set and `setup-gradle`'s caching is **active**, the action instead
+warns: both it and the other action are caching the same Gradle User Home, which is
+usually a mistake.
+
+##### Contract for action authors
+
+This variable is the integration point between `setup-gradle` and a co-resident caching
+action. If you are writing such an action:
+
+- **Export it only once you have determined that your action will actually provide
+  dependency caching for this job** — not unconditionally at the start of your step. The
+  "caching was disabled" wording it replaces is a diagnostic that helps users notice a
+  `cache-disabled: true` they did not intend; claiming caching you do not provide takes
+  that diagnostic away from them.
+- Export it from your **main** step. `setup-gradle` reads it in its post step, when the
+  Job Summary is written.
+- The presence of the variable is the signal; the value is only a display label. Labels
+  are rendered into the Job Summary, so only a conservative character set is accepted
+  (letters, digits, spaces, and `. _ - & +`, up to 60 characters). A label outside that
+  set is not rendered and the summary falls back to "another action in this workflow" —
+  the attribution still happens, just unnamed.
 
 > [!NOTE]
-> `GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER` is the integration point between `setup-gradle`
-> and a co-resident caching action. Its name and contract are still being finalized.
+> The name and value shape of `GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER` are still being
+> finalized.
 
 #### Using the cache read-only
 

--- a/sources/src/cache-service-loader.ts
+++ b/sources/src/cache-service-loader.ts
@@ -52,6 +52,25 @@ export function getProviderNote(cacheConfig: CacheConfig): ProviderNote | undefi
     return cacheConfig.getCacheProvider() === CacheProvider.Basic ? {kind: 'basic'} : {kind: 'enhanced'}
 }
 
+/**
+ * Re-labels a disabled cache report when another action in the workflow is providing
+ * dependency caching (advertised via GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER). This turns
+ * the summary's misleading "caching was disabled" into an accurate "handled externally by
+ * <provider>" line. Only a plain `disabled` report is re-labelled — an enabled/read-only
+ * cache, a skipped/unavailable one, or a report with no external provider set is returned
+ * unchanged.
+ */
+export function applyExternalCacheProvider(report: CacheReport, cacheConfig: CacheConfig): CacheReport {
+    if (report.status !== 'disabled') {
+        return report
+    }
+    const provider = cacheConfig.getExternalCacheProvider()
+    if (!provider) {
+        return report
+    }
+    return {...report, status: 'disabled-external', externalCacheProvider: provider}
+}
+
 export async function loadVendoredCacheService(): Promise<CacheService> {
     const vendoredLibraryPath = findVendoredLibraryPath()
     const moduleUrl = pathToFileURL(vendoredLibraryPath).href

--- a/sources/src/cache-service-loader.ts
+++ b/sources/src/cache-service-loader.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import * as fs from 'fs'
 import * as path from 'path'
 import {pathToFileURL} from 'url'
@@ -6,7 +7,7 @@ import {CacheConfig, CacheProvider} from './configuration'
 import {BasicCacheService} from './cache-service-basic'
 import {BuildResult} from './build-results'
 import {CacheOptions, CacheReport, CacheService} from './cache-service'
-import {ProviderNote} from './caching-report'
+import {isActive, ProviderNote} from './caching-report'
 
 const ENHANCED_CACHE_MESSAGE = `Enhanced Caching: This build is using the proprietary 'gradle-actions-caching' provider for optimized caching support. See https://github.com/gradle/actions/blob/main/DISTRIBUTION.md for terms of use and opt-out instructions.`
 
@@ -53,22 +54,40 @@ export function getProviderNote(cacheConfig: CacheConfig): ProviderNote | undefi
 }
 
 /**
- * Re-labels a disabled cache report when another action in the workflow is providing
- * dependency caching (advertised via GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER). This turns
- * the summary's misleading "caching was disabled" into an accurate "handled externally by
- * <provider>" line. Only a plain `disabled` report is re-labelled — an enabled/read-only
- * cache, a skipped/unavailable one, or a report with no external provider set is returned
- * unchanged.
+ * Reconciles the cache report with any other action in this workflow that has advertised
+ * itself as handling dependency caching (via GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER).
+ *
+ * When our own caching is disabled, this re-labels the report so the summary attributes
+ * the disabled Gradle User Home cache to that action instead of reporting a bare "caching
+ * was disabled" alongside the other action's own caching report.
+ *
+ * Note this only softens the wording — the report still states that caching is disabled
+ * here, so a user who disabled it by mistake is not left in the dark. The one case that
+ * wording cannot cover is the opposite mistake: caching left *enabled* while another
+ * action caches the same Gradle User Home. That is warned about rather than re-labelled.
  */
-export function applyExternalCacheProvider(report: CacheReport, cacheConfig: CacheConfig): CacheReport {
+export function applyExternalCacheHandler(report: CacheReport, cacheConfig: CacheConfig): CacheReport {
+    const handler = cacheConfig.getExternalCacheHandler()
+    if (!handler) {
+        return report
+    }
+    const handlerName = handler.label ?? 'Another action'
+
+    if (isActive(report.status)) {
+        core.warning(
+            `${handlerName} is providing dependency caching in this workflow, but setup-gradle caching is also enabled — ` +
+                `both are caching the Gradle User Home. Set 'cache-disabled: true' to leave dependency caching to ${handlerName}.`
+        )
+        return report
+    }
+
+    // 'disabled' is the only status reachable when caching is disabled: getCacheService
+    // short-circuits to the no-op service, so the statuses reported by the real cache
+    // service ('disabled-existing-home', 'not-available') cannot arise here.
     if (report.status !== 'disabled') {
         return report
     }
-    const provider = cacheConfig.getExternalCacheProvider()
-    if (!provider) {
-        return report
-    }
-    return {...report, status: 'disabled-external', externalCacheProvider: provider}
+    return {...report, status: 'disabled-external', externalCacheHandler: handler.label}
 }
 
 export async function loadVendoredCacheService(): Promise<CacheService> {

--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -15,7 +15,13 @@ export interface CacheOptions {
 }
 
 export type CacheStatus =
-    'enabled' | 'read-only' | 'write-only' | 'disabled' | 'disabled-existing-home' | 'not-available'
+    | 'enabled'
+    | 'read-only'
+    | 'write-only'
+    | 'disabled'
+    | 'disabled-external' // disabled here because dependency caching is provided by another action in the workflow
+    | 'disabled-existing-home'
+    | 'not-available'
 
 export type CacheCleanupStatus =
     'enabled' | 'disabled-param' | 'disabled-failure' | 'disabled-config-cache-hit' | 'disabled-readonly'
@@ -49,6 +55,9 @@ export interface CacheReport {
     cleanup?: CacheCleanupStatus
     projectCache?: ProjectCacheStatus
     entries: CacheEntryReport[]
+    // The display label of the external action providing dependency caching, set only
+    // when status is 'disabled-external'. Sourced from GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER.
+    externalCacheProvider?: string
 }
 
 export interface CacheService {

--- a/sources/src/cache-service.ts
+++ b/sources/src/cache-service.ts
@@ -19,7 +19,7 @@ export type CacheStatus =
     | 'read-only'
     | 'write-only'
     | 'disabled'
-    | 'disabled-external' // disabled here because dependency caching is provided by another action in the workflow
+    | 'disabled-external' // disabled here because dependency caching is handled by another action in the workflow
     | 'disabled-existing-home'
     | 'not-available'
 
@@ -55,9 +55,10 @@ export interface CacheReport {
     cleanup?: CacheCleanupStatus
     projectCache?: ProjectCacheStatus
     entries: CacheEntryReport[]
-    // The display label of the external action providing dependency caching, set only
-    // when status is 'disabled-external'. Sourced from GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER.
-    externalCacheProvider?: string
+    // Display label of the external action handling dependency caching. Only meaningful
+    // when status is 'disabled-external', and optional even then: the action advertises
+    // itself by presence, and may not supply a label we are willing to render.
+    externalCacheHandler?: string
 }
 
 export interface CacheService {

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -22,12 +22,13 @@ const STATUS_COPY: Record<CacheStatus, string> = {
 }
 
 /**
- * The status line for a report. Normally the static {@link STATUS_COPY} entry, but for a
- * cache disabled in favour of an external provider it names that provider (when known).
+ * The status line for a report. Normally the static {@link STATUS_COPY} entry, but a cache
+ * disabled in favour of an external handler names that handler when it supplied a usable
+ * label; without one, the generic {@link STATUS_COPY} entry applies.
  */
 function statusCopy(report: CacheReport): string {
-    if (report.status === 'disabled-external' && report.externalCacheProvider) {
-        return `[Caching was disabled](${DOCS}#disabling-caching) here — Gradle User Home caching is turned off because dependency caching is handled by **${report.externalCacheProvider}** in this workflow.`
+    if (report.status === 'disabled-external' && report.externalCacheHandler) {
+        return `[Caching was disabled](${DOCS}#disabling-caching) here — Gradle User Home caching is turned off because dependency caching is handled by **${report.externalCacheHandler}** in this workflow.`
     }
     return STATUS_COPY[report.status]
 }
@@ -68,7 +69,7 @@ export function renderCachingReport(report: CacheReport, providerNote?: Provider
     return `${sections.filter(section => section !== undefined && section !== '').join('\n\n')}\n`
 }
 
-function isActive(status: CacheStatus): boolean {
+export function isActive(status: CacheStatus): boolean {
     return status === 'enabled' || status === 'read-only' || status === 'write-only'
 }
 

--- a/sources/src/caching-report.ts
+++ b/sources/src/caching-report.ts
@@ -16,8 +16,20 @@ const STATUS_COPY: Record<CacheStatus, string> = {
     'read-only': `[Cache was read-only](${DOCS}#using-the-cache-read-only) — by default, the action only writes to the cache for jobs running on the default branch.`,
     'write-only': `[Cache was write-only](${DOCS}#using-the-cache-write-only) — Gradle User Home was not restored from the cache.`,
     disabled: `[Caching was disabled](${DOCS}#disabling-caching) — Gradle User Home was not restored from or saved to the cache.`,
+    'disabled-external': `[Caching was disabled](${DOCS}#disabling-caching) here — Gradle User Home caching is turned off because dependency caching is handled by another action in this workflow.`,
     'disabled-existing-home': `⚠️ [Caching was skipped](${DOCS}#overwriting-an-existing-gradle-user-home) — a pre-existing Gradle User Home was found, so the cache was not restored or saved.`,
     'not-available': `Caching is not available — the GitHub Actions cache service could not be reached, so Gradle User Home was not restored or saved.`
+}
+
+/**
+ * The status line for a report. Normally the static {@link STATUS_COPY} entry, but for a
+ * cache disabled in favour of an external provider it names that provider (when known).
+ */
+function statusCopy(report: CacheReport): string {
+    if (report.status === 'disabled-external' && report.externalCacheProvider) {
+        return `[Caching was disabled](${DOCS}#disabling-caching) here — Gradle User Home caching is turned off because dependency caching is handled by **${report.externalCacheProvider}** in this workflow.`
+    }
+    return STATUS_COPY[report.status]
 }
 
 const CLEANUP_COPY: Record<CacheCleanupStatus, string> = {
@@ -44,7 +56,7 @@ const PROJECT_CACHE_COPY: Record<ProjectCacheStatus, string> = {
 export function renderCachingReport(report: CacheReport, providerNote?: ProviderNote): string {
     if (!isActive(report.status)) {
         // Disabled / skipped / unavailable: a compact heading + status line, no expandable section.
-        return `${renderHeading(report.status, providerNote)}\n\n${STATUS_COPY[report.status]}\n`
+        return `${renderHeading(report.status, providerNote)}\n\n${statusCopy(report)}\n`
     }
     const sections = [
         renderHeading(report.status, providerNote),
@@ -63,7 +75,13 @@ function isActive(status: CacheStatus): boolean {
 function renderHeading(status: CacheStatus, providerNote?: ProviderNote): string {
     if (!isActive(status)) {
         const label =
-            status === 'disabled-existing-home' ? 'Skipped' : status === 'not-available' ? 'Unavailable' : 'Disabled'
+            status === 'disabled-existing-home'
+                ? 'Skipped'
+                : status === 'not-available'
+                  ? 'Unavailable'
+                  : status === 'disabled-external'
+                    ? 'Disabled (handled externally)'
+                    : 'Disabled'
         return `<h4>Gradle State Caching - ${label}</h4>`
     }
 

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -8,6 +8,11 @@ import * as path from 'path'
 const ACTION_ID_VAR = 'GRADLE_ACTION_ID'
 const SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY'
 
+// Environment variable an external dependency-caching action (e.g. the Develocity
+// Artifact Cache action) exports to advertise that it is handling caching in this
+// workflow. Its value is a human-readable provider label shown in the Job Summary.
+const EXTERNAL_CACHE_PROVIDER_ENV_VAR = 'GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER'
+
 export const ACTION_METADATA_DIR = '.setup-gradle'
 
 export class DependencyGraphConfig {
@@ -114,6 +119,30 @@ export class CacheConfig {
         }
 
         return getBooleanInput('cache-disabled')
+    }
+
+    /**
+     * The display label of an external action providing dependency caching in this
+     * workflow, read from the GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER environment
+     * variable (exported by that action). When set, and Gradle User Home caching is
+     * disabled, the Job Summary attributes the disabled cache to this provider rather
+     * than reporting a bare "caching was disabled". Returns undefined when unset.
+     *
+     * The value is sanitized before use: HTML-sensitive characters and newlines are
+     * stripped, whitespace is collapsed, and the label is capped in length, since it
+     * originates from another action and is rendered into the summary markdown.
+     */
+    getExternalCacheProvider(): string | undefined {
+        const raw = process.env[EXTERNAL_CACHE_PROVIDER_ENV_VAR]
+        if (!raw) {
+            return undefined
+        }
+        const label = raw
+            .replace(/[<>`\r\n]/g, '')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .slice(0, 60)
+        return label.length > 0 ? label : undefined
     }
 
     isCacheReadOnly(): boolean {

--- a/sources/src/configuration.ts
+++ b/sources/src/configuration.ts
@@ -10,8 +10,17 @@ const SUMMARY_ENV_VAR = 'GITHUB_STEP_SUMMARY'
 
 // Environment variable an external dependency-caching action (e.g. the Develocity
 // Artifact Cache action) exports to advertise that it is handling caching in this
-// workflow. Its value is a human-readable provider label shown in the Job Summary.
-const EXTERNAL_CACHE_PROVIDER_ENV_VAR = 'GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER'
+// workflow. Its value is a human-readable label shown in the Job Summary.
+//
+// NOTE: this name is the integration point between setup-gradle and a co-resident
+// caching action, and is not yet codified. See docs/setup-gradle.md.
+const EXTERNAL_CACHE_HANDLER_ENV_VAR = 'GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER'
+
+// Labels reach us from another action and are rendered into the Job Summary markdown.
+// Rather than stripping dangerous characters — which silently mangles the label and
+// still leaves markdown syntax (links, emphasis, tables) live — accept only a
+// conservative character set and fall back to an unnamed handler for anything else.
+const EXTERNAL_CACHE_LABEL_PATTERN = /^[\w .&+-]{1,60}$/
 
 export const ACTION_METADATA_DIR = '.setup-gradle'
 
@@ -112,6 +121,15 @@ export enum DependencyGraphOption {
     DownloadAndSubmit = 'download-and-submit'
 }
 
+/**
+ * Another action in this workflow that has advertised itself as handling dependency
+ * caching. `label` is a display name for the Job Summary, absent when the advertised
+ * label was not usable.
+ */
+export interface ExternalCacheHandler {
+    label?: string
+}
+
 export class CacheConfig {
     isCacheDisabled(): boolean {
         if (!cache.isFeatureAvailable()) {
@@ -122,27 +140,28 @@ export class CacheConfig {
     }
 
     /**
-     * The display label of an external action providing dependency caching in this
-     * workflow, read from the GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER environment
-     * variable (exported by that action). When set, and Gradle User Home caching is
-     * disabled, the Job Summary attributes the disabled cache to this provider rather
-     * than reporting a bare "caching was disabled". Returns undefined when unset.
+     * The external action handling dependency caching in this workflow, advertised by
+     * that action via the GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER environment variable.
+     * Returns undefined when no such action has advertised itself.
      *
-     * The value is sanitized before use: HTML-sensitive characters and newlines are
-     * stripped, whitespace is collapsed, and the label is capped in length, since it
-     * originates from another action and is rendered into the summary markdown.
+     * Presence of the variable is the signal; the value is only a display label. A label
+     * that is unusable (empty, or containing characters we will not render into the
+     * summary markdown) still yields a handler, just an unnamed one — refusing the signal
+     * over cosmetics would misreport the job as having no caching at all.
      */
-    getExternalCacheProvider(): string | undefined {
-        const raw = process.env[EXTERNAL_CACHE_PROVIDER_ENV_VAR]
-        if (!raw) {
+    getExternalCacheHandler(): ExternalCacheHandler | undefined {
+        const raw = process.env[EXTERNAL_CACHE_HANDLER_ENV_VAR]
+        if (!raw || raw.trim().length === 0) {
             return undefined
         }
-        const label = raw
-            .replace(/[<>`\r\n]/g, '')
-            .replace(/\s+/g, ' ')
-            .trim()
-            .slice(0, 60)
-        return label.length > 0 ? label : undefined
+        const label = raw.replace(/\s+/g, ' ').trim()
+        if (!EXTERNAL_CACHE_LABEL_PATTERN.test(label)) {
+            core.debug(
+                `Ignoring unusable ${EXTERNAL_CACHE_HANDLER_ENV_VAR} label '${label}': reporting an unnamed external cache handler.`
+            )
+            return {}
+        }
+        return {label}
     }
 
     isCacheReadOnly(): boolean {

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -8,7 +8,7 @@ import * as buildScan from './develocity/build-scan'
 import {setupToken} from './develocity/short-lived-token'
 
 import {loadBuildResults, markBuildResultsProcessed} from './build-results'
-import {getCacheService, getProviderNote} from './cache-service-loader'
+import {applyExternalCacheProvider, getCacheService, getProviderNote} from './cache-service-loader'
 import {CacheOptions} from './cache-service'
 import {
     DevelocityConfig,
@@ -80,10 +80,13 @@ export async function complete(
     const develocityServerUrl = develocityConfig.getDevelocityUrl() || undefined
     const cacheToken = core.getState(DEVELOCITY_CACHE_TOKEN) || undefined
     const cacheService = await getCacheService(cacheConfig)
-    const cacheReport = await cacheService.save(
-        gradleUserHome,
-        buildResults,
-        cacheOptionsFrom(cacheConfig, develocityServerUrl, cacheToken)
+    const cacheReport = applyExternalCacheProvider(
+        await cacheService.save(
+            gradleUserHome,
+            buildResults,
+            cacheOptionsFrom(cacheConfig, develocityServerUrl, cacheToken)
+        ),
+        cacheConfig
     )
     await jobSummary.generateJobSummary(buildResults, cacheReport, getProviderNote(cacheConfig), summaryConfig)
 

--- a/sources/src/setup-gradle.ts
+++ b/sources/src/setup-gradle.ts
@@ -8,7 +8,7 @@ import * as buildScan from './develocity/build-scan'
 import {setupToken} from './develocity/short-lived-token'
 
 import {loadBuildResults, markBuildResultsProcessed} from './build-results'
-import {applyExternalCacheProvider, getCacheService, getProviderNote} from './cache-service-loader'
+import {applyExternalCacheHandler, getCacheService, getProviderNote} from './cache-service-loader'
 import {CacheOptions} from './cache-service'
 import {
     DevelocityConfig,
@@ -80,7 +80,7 @@ export async function complete(
     const develocityServerUrl = develocityConfig.getDevelocityUrl() || undefined
     const cacheToken = core.getState(DEVELOCITY_CACHE_TOKEN) || undefined
     const cacheService = await getCacheService(cacheConfig)
-    const cacheReport = applyExternalCacheProvider(
+    const cacheReport = applyExternalCacheHandler(
         await cacheService.save(
             gradleUserHome,
             buildResults,

--- a/sources/test/jest/cache-service-loader.test.ts
+++ b/sources/test/jest/cache-service-loader.test.ts
@@ -76,4 +76,37 @@ describe('getCacheService selection logic', () => {
             expect(getProviderNote(mockConfig)).toEqual({kind: 'enhanced'})
         })
     })
+
+    describe('applyExternalCacheProvider', () => {
+        const disabledReport = {status: 'disabled' as const, entries: []}
+
+        it('re-labels a disabled report when an external provider is advertised', async () => {
+            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
+            const mockConfig = {
+                getExternalCacheProvider: () => 'Develocity Artifact Cache'
+            } as unknown as CacheConfig
+
+            const result = applyExternalCacheProvider(disabledReport, mockConfig)
+
+            expect(result.status).toBe('disabled-external')
+            expect(result.externalCacheProvider).toBe('Develocity Artifact Cache')
+        })
+
+        it('leaves a disabled report unchanged when no external provider is set', async () => {
+            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
+            const mockConfig = {getExternalCacheProvider: () => undefined} as unknown as CacheConfig
+
+            expect(applyExternalCacheProvider(disabledReport, mockConfig)).toBe(disabledReport)
+        })
+
+        it('never re-labels an active cache even when a provider is advertised', async () => {
+            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
+            const enabledReport = {status: 'enabled' as const, entries: []}
+            const mockConfig = {
+                getExternalCacheProvider: () => 'Develocity Artifact Cache'
+            } as unknown as CacheConfig
+
+            expect(applyExternalCacheProvider(enabledReport, mockConfig)).toBe(enabledReport)
+        })
+    })
 })

--- a/sources/test/jest/cache-service-loader.test.ts
+++ b/sources/test/jest/cache-service-loader.test.ts
@@ -3,9 +3,24 @@ import {describe, expect, it, jest, beforeEach} from '@jest/globals'
 import {CacheProvider} from '../../src/configuration'
 import type {CacheConfig} from '../../src/configuration'
 
+/**
+ * Captures the workflow commands core.* writes to stdout. ESM namespaces are frozen, so
+ * @actions/core cannot be spied on directly, and mocking the module would break the
+ * node_modules packages that also import it.
+ */
+function captureWorkflowCommands(): string[] {
+    const written: string[] = []
+    jest.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown): boolean => {
+        written.push(String(chunk))
+        return true
+    }) as never)
+    return written
+}
+
 describe('getCacheService selection logic', () => {
     beforeEach(() => {
         jest.restoreAllMocks()
+        jest.clearAllMocks()
     })
 
     it('returns NoOpCacheService when cache is disabled', async () => {
@@ -77,36 +92,67 @@ describe('getCacheService selection logic', () => {
         })
     })
 
-    describe('applyExternalCacheProvider', () => {
+    describe('applyExternalCacheHandler', () => {
         const disabledReport = {status: 'disabled' as const, entries: []}
+        const configWith = (handler: {label?: string} | undefined): CacheConfig =>
+            ({getExternalCacheHandler: () => handler}) as unknown as CacheConfig
 
-        it('re-labels a disabled report when an external provider is advertised', async () => {
-            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
-            const mockConfig = {
-                getExternalCacheProvider: () => 'Develocity Artifact Cache'
-            } as unknown as CacheConfig
+        it('re-labels a disabled report when an external handler is advertised', async () => {
+            const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
 
-            const result = applyExternalCacheProvider(disabledReport, mockConfig)
+            const result = applyExternalCacheHandler(disabledReport, configWith({label: 'Develocity Artifact Cache'}))
 
             expect(result.status).toBe('disabled-external')
-            expect(result.externalCacheProvider).toBe('Develocity Artifact Cache')
+            expect(result.externalCacheHandler).toBe('Develocity Artifact Cache')
         })
 
-        it('leaves a disabled report unchanged when no external provider is set', async () => {
-            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
-            const mockConfig = {getExternalCacheProvider: () => undefined} as unknown as CacheConfig
+        it('re-labels a disabled report when the handler supplied no usable label', async () => {
+            const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
 
-            expect(applyExternalCacheProvider(disabledReport, mockConfig)).toBe(disabledReport)
+            const result = applyExternalCacheHandler(disabledReport, configWith({}))
+
+            expect(result.status).toBe('disabled-external')
+            expect(result.externalCacheHandler).toBeUndefined()
         })
 
-        it('never re-labels an active cache even when a provider is advertised', async () => {
-            const {applyExternalCacheProvider} = await import('../../src/cache-service-loader')
-            const enabledReport = {status: 'enabled' as const, entries: []}
-            const mockConfig = {
-                getExternalCacheProvider: () => 'Develocity Artifact Cache'
-            } as unknown as CacheConfig
+        it('leaves a disabled report unchanged when no external handler is advertised', async () => {
+            const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
 
-            expect(applyExternalCacheProvider(enabledReport, mockConfig)).toBe(enabledReport)
+            expect(applyExternalCacheHandler(disabledReport, configWith(undefined))).toBe(disabledReport)
+        })
+
+        it.each(['enabled', 'read-only', 'write-only'] as const)(
+            'warns rather than re-labelling when the cache is %s',
+            async status => {
+                const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
+                const activeReport = {status, entries: []}
+                const written = captureWorkflowCommands()
+
+                const result = applyExternalCacheHandler(activeReport, configWith({label: 'Develocity Artifact Cache'}))
+
+                expect(result).toBe(activeReport)
+                const warning = written.find(line => line.startsWith('::warning::'))
+                expect(warning).toContain('Develocity Artifact Cache is providing dependency caching')
+                expect(warning).toContain("'cache-disabled: true'")
+            }
+        )
+
+        it('names an unnamed handler generically in the warning', async () => {
+            const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
+            const written = captureWorkflowCommands()
+
+            applyExternalCacheHandler({status: 'enabled', entries: []}, configWith({}))
+
+            expect(written.find(line => line.startsWith('::warning::'))).toContain('Another action is providing')
+        })
+
+        it('does not warn when the cache is disabled', async () => {
+            const {applyExternalCacheHandler} = await import('../../src/cache-service-loader')
+            const written = captureWorkflowCommands()
+
+            applyExternalCacheHandler(disabledReport, configWith({label: 'Develocity Artifact Cache'}))
+
+            expect(written.find(line => line.startsWith('::warning::'))).toBeUndefined()
         })
     })
 })

--- a/sources/test/jest/caching-report.test.ts
+++ b/sources/test/jest/caching-report.test.ts
@@ -143,10 +143,10 @@ describe('renderCachingReport', () => {
         expect(md).not.toContain('<details>')
     })
 
-    it('names the external provider when caching is handled elsewhere', () => {
+    it('names the external handler when caching is handled elsewhere', () => {
         const report: CacheReport = {
             status: 'disabled-external',
-            externalCacheProvider: 'Develocity Artifact Cache',
+            externalCacheHandler: 'Develocity Artifact Cache',
             entries: []
         }
         const md = renderCachingReport(report, undefined)
@@ -157,12 +157,24 @@ describe('renderCachingReport', () => {
         expect(md).not.toContain('DISTRIBUTION.md')
     })
 
-    it('falls back to a generic external message when no provider label is set', () => {
+    it('falls back to a generic external message when no handler label is set', () => {
         const report: CacheReport = {status: 'disabled-external', entries: []}
         const md = renderCachingReport(report, undefined)
 
         expect(md).toContain('<h4>Gradle State Caching - Disabled (handled externally)</h4>')
         expect(md).toContain('dependency caching is handled by another action in this workflow')
         expect(md).not.toContain('<details>')
+    })
+
+    it('still reports that caching is disabled here, so an unintended opt-out is visible', () => {
+        const report: CacheReport = {
+            status: 'disabled-external',
+            externalCacheHandler: 'Develocity Artifact Cache',
+            entries: []
+        }
+        const md = renderCachingReport(report, undefined)
+
+        expect(md).toContain('Disabled')
+        expect(md).toContain('Caching was disabled')
     })
 })

--- a/sources/test/jest/caching-report.test.ts
+++ b/sources/test/jest/caching-report.test.ts
@@ -142,4 +142,27 @@ describe('renderCachingReport', () => {
         expect(md).toContain('<h4>Gradle State Caching - Unavailable</h4>')
         expect(md).not.toContain('<details>')
     })
+
+    it('names the external provider when caching is handled elsewhere', () => {
+        const report: CacheReport = {
+            status: 'disabled-external',
+            externalCacheProvider: 'Develocity Artifact Cache',
+            entries: []
+        }
+        const md = renderCachingReport(report, undefined)
+
+        expect(md).toContain('<h4>Gradle State Caching - Disabled (handled externally)</h4>')
+        expect(md).toContain('dependency caching is handled by **Develocity Artifact Cache** in this workflow')
+        expect(md).not.toContain('<details>')
+        expect(md).not.toContain('DISTRIBUTION.md')
+    })
+
+    it('falls back to a generic external message when no provider label is set', () => {
+        const report: CacheReport = {status: 'disabled-external', entries: []}
+        const md = renderCachingReport(report, undefined)
+
+        expect(md).toContain('<h4>Gradle State Caching - Disabled (handled externally)</h4>')
+        expect(md).toContain('dependency caching is handled by another action in this workflow')
+        expect(md).not.toContain('<details>')
+    })
 })

--- a/sources/test/jest/configuration.test.ts
+++ b/sources/test/jest/configuration.test.ts
@@ -22,3 +22,45 @@ describe('input params', () => {
         })
     })
 })
+
+describe('CacheConfig.getExternalCacheProvider', () => {
+    const ENV_VAR = 'GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER'
+    const original = process.env[ENV_VAR]
+
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env[ENV_VAR]
+        } else {
+            process.env[ENV_VAR] = original
+        }
+    })
+
+    function provider(): string | undefined {
+        return new inputParams.CacheConfig().getExternalCacheProvider()
+    }
+
+    it('returns undefined when the env var is unset', () => {
+        delete process.env[ENV_VAR]
+        expect(provider()).toBeUndefined()
+    })
+
+    it('returns undefined when the env var is empty or whitespace', () => {
+        process.env[ENV_VAR] = '   '
+        expect(provider()).toBeUndefined()
+    })
+
+    it('returns the provider label when set', () => {
+        process.env[ENV_VAR] = 'Develocity Artifact Cache'
+        expect(provider()).toBe('Develocity Artifact Cache')
+    })
+
+    it('sanitizes HTML-sensitive characters, newlines, and collapses whitespace', () => {
+        process.env[ENV_VAR] = '  <b>Develocity`</b>\n Artifact   Cache  '
+        expect(provider()).toBe('bDevelocity/b Artifact Cache')
+    })
+
+    it('caps the label length', () => {
+        process.env[ENV_VAR] = 'x'.repeat(200)
+        expect(provider()).toHaveLength(60)
+    })
+})

--- a/sources/test/jest/configuration.test.ts
+++ b/sources/test/jest/configuration.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it} from '@jest/globals'
+import {afterEach, describe, expect, it} from '@jest/globals'
 
 import * as inputParams from '../../src/configuration'
 
@@ -23,7 +23,7 @@ describe('input params', () => {
     })
 })
 
-describe('CacheConfig.getExternalCacheProvider', () => {
+describe('CacheConfig.getExternalCacheHandler', () => {
     const ENV_VAR = 'GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER'
     const original = process.env[ENV_VAR]
 
@@ -35,32 +35,45 @@ describe('CacheConfig.getExternalCacheProvider', () => {
         }
     })
 
-    function provider(): string | undefined {
-        return new inputParams.CacheConfig().getExternalCacheProvider()
+    function handler(): inputParams.ExternalCacheHandler | undefined {
+        return new inputParams.CacheConfig().getExternalCacheHandler()
     }
 
     it('returns undefined when the env var is unset', () => {
         delete process.env[ENV_VAR]
-        expect(provider()).toBeUndefined()
+        expect(handler()).toBeUndefined()
     })
 
     it('returns undefined when the env var is empty or whitespace', () => {
         process.env[ENV_VAR] = '   '
-        expect(provider()).toBeUndefined()
+        expect(handler()).toBeUndefined()
     })
 
-    it('returns the provider label when set', () => {
+    it('returns the label when set', () => {
         process.env[ENV_VAR] = 'Develocity Artifact Cache'
-        expect(provider()).toBe('Develocity Artifact Cache')
+        expect(handler()).toEqual({label: 'Develocity Artifact Cache'})
     })
 
-    it('sanitizes HTML-sensitive characters, newlines, and collapses whitespace', () => {
-        process.env[ENV_VAR] = '  <b>Develocity`</b>\n Artifact   Cache  '
-        expect(provider()).toBe('bDevelocity/b Artifact Cache')
+    it('trims and collapses whitespace, including newlines', () => {
+        process.env[ENV_VAR] = '  Develocity \n  Artifact  Cache  '
+        expect(handler()).toEqual({label: 'Develocity Artifact Cache'})
     })
 
-    it('caps the label length', () => {
-        process.env[ENV_VAR] = 'x'.repeat(200)
-        expect(provider()).toHaveLength(60)
+    it.each([
+        ['HTML', '<b>Develocity</b>'],
+        ['a markdown link', '[Develocity](https://example.com)'],
+        ['markdown emphasis', '**Develocity**'],
+        ['a table separator', 'Develocity | Artifact Cache'],
+        ['a backtick', 'Develocity `Artifact` Cache'],
+        ['an over-long label', 'x'.repeat(61)]
+    ])('reports an unnamed handler rather than rendering %s', (_description, value) => {
+        process.env[ENV_VAR] = value
+        // Still a handler — the signal is honoured, only the label is dropped.
+        expect(handler()).toEqual({})
+    })
+
+    it('accepts the punctuation commonly found in product names', () => {
+        process.env[ENV_VAR] = 'Foo_Bar & Co. C++ cache-action'
+        expect(handler()).toEqual({label: 'Foo_Bar & Co. C++ cache-action'})
     })
 })


### PR DESCRIPTION
## Problem

When a workflow disables `setup-gradle`'s caching because another action provides dependency caching (e.g. the Develocity Artifact Cache action), the Job Summary still reports a bare **"Caching was disabled — Gradle User Home was not restored from or saved to the cache."** Shown alongside the other action's own caching summary, this reads as contradictory: caching *is* happening in the job, just not via `setup-gradle`'s Gradle User Home cache.

Real example (Develocity Artifact Cache + `setup-gradle` with `cache-disabled: true`): the summary shows two caching sections, one saying caching is disabled and one showing active cache restores/stores.

## Change

A co-resident caching action can now advertise itself by exporting an environment variable:

```
GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER=<display label>
```

When that variable is set **and** `setup-gradle`'s own caching is disabled, the caching section of the Job Summary changes from a bare "disabled" to attributing the cache to the named provider.

**Before**
> #### Gradle State Caching - Disabled
> Caching was disabled — Gradle User Home was not restored from or saved to the cache.

**After**
> #### Gradle State Caching - Disabled (handled externally)
> Caching was disabled here — Gradle User Home caching is turned off because dependency caching is handled by **Develocity Artifact Cache** in this workflow.

Only a plain `disabled` cache is re-labelled — active (enabled / read-only / write-only), skipped (`disabled-existing-home`), and unavailable states are untouched, and the variable has no effect when caching is active. The provider label is sanitized before rendering (HTML-sensitive characters and newlines stripped, whitespace collapsed, length capped) since it originates from another action.

### Files
- `cache-service.ts` — new `disabled-external` `CacheStatus` + optional `externalCacheProvider` label on `CacheReport`.
- `configuration.ts` — `CacheConfig.getExternalCacheProvider()` reads and sanitizes the env var.
- `cache-service-loader.ts` — `applyExternalCacheProvider()` re-labels a disabled report when the provider is advertised.
- `setup-gradle.ts` — applies the transform to the save result before rendering.
- `caching-report.ts` — heading + status-line copy for the new state.
- `docs/setup-gradle.md` — documents the variable.
- Tests for all of the above.

No `dist/**` changes (per `ci-check-no-dist-update`; the bot regenerates `dist` on merge).

## ⚠️ API contract to codify

**`GRADLE_ACTIONS_EXTERNAL_CACHE_PROVIDER` is the integration point between `setup-gradle` and any co-resident caching action** — its name and value contract are a public API that both sides must agree on. I've picked this name to get the feature working, but **it should be reviewed and codified** (name, whether the value is a free-form label vs. a known identifier, sanitization rules). Happy to rename to match whatever convention you prefer.

## Companion change

A companion change in the Develocity Artifact Cache action exports this variable; that action lives in a private Gradle repository. (Link to follow in a comment for those with access.)

## Verification

- `npm test` — all suites pass (incl. new tests in `caching-report`, `configuration`, `cache-service-loader`).
- `npm run check` (prettier + eslint) — clean.
