### PR TITLE
Add action heading to Gradle job summary

### DIFF
--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -15,8 +15,11 @@ export async function generateJobSummary(
 ): Promise<void> {
     core.startGroup('Generating Job Summary')
 
+    const heading = renderActionHeading()
+
     const errors = renderErrors()
     if (errors) {
+        core.summary.addRaw(heading)
         core.summary.addRaw(errors)
         await core.summary.write()
         return
@@ -31,6 +34,7 @@ export async function generateJobSummary(
     core.info(cachingReport)
 
     if (config.shouldGenerateJobSummary(hasFailure)) {
+        core.summary.addRaw(heading)
         core.summary.addRaw(summaryTable)
         core.summary.addRaw(cachingReport)
         await core.summary.write()
@@ -95,6 +99,11 @@ Note that this permission is never available for a workflow triggered from a rep
 
 export function renderSummaryTable(results: BuildResult[]): string {
     return `${renderDeprecations()}\n${renderBuildResults(results)}`
+}
+
+function renderActionHeading(): string {
+    const actionId = getActionId()
+    return actionId ? `<h3>Gradle Builds (${actionId})</h3>\n\n` : `<h3>Gradle Builds</h3>\n\n`
 }
 
 function renderErrors(): string | undefined {

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -102,7 +102,7 @@ export function renderSummaryTable(results: BuildResult[]): string {
 
 function renderActionHeading(): string {
     const actionId = getActionId()
-    const caption = actionId ? ` <small><em>captured by ${actionId}</em></small>` : ''
+    const caption = actionId ? ` <sub><em>captured by ${actionId}</em></sub>` : ''
     return `<h3>Gradle Builds${caption}</h3>\n\n`
 }
 

--- a/sources/src/job-summary.ts
+++ b/sources/src/job-summary.ts
@@ -61,8 +61,7 @@ async function addPRComment(jobSummary: string): Promise<void> {
     core.info(`Adding Job Summary as comment to PR #${pull_request_number}.`)
 
     const prComment = `${jobMarker(context)}
-<h3>Job Summary for Gradle</h3>
-<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}" target="_blank">
+${renderActionHeading()}<a href="${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}" target="_blank">
 <h5>${context.workflow} :: <em>${context.job}</em></h5>
 </a>
 
@@ -103,7 +102,8 @@ export function renderSummaryTable(results: BuildResult[]): string {
 
 function renderActionHeading(): string {
     const actionId = getActionId()
-    return actionId ? `<h3>Gradle Builds (${actionId})</h3>\n\n` : `<h3>Gradle Builds</h3>\n\n`
+    const caption = actionId ? ` <small><em>captured by ${actionId}</em></small>` : ''
+    return `<h3>Gradle Builds${caption}</h3>\n\n`
 }
 
 function renderErrors(): string | undefined {


### PR DESCRIPTION
Job summaries from setup-gradle/dependency-submission had no top-level heading, so they read poorly when another action's summary content lands in the same job. Name the action explicitly so the block is attributable when summaries are stacked.