### PR TITLE
Report gradle version as a dependency

### DIFF
--- a/.github/workflows/integ-test-dependency-submission.yml
+++ b/.github/workflows/integ-test-dependency-submission.yml
@@ -160,6 +160,45 @@ jobs:
             echo "Did not find groovy-dsl-again dependency graph file"
             exit 1
         fi
+        for report in dependency-graph-reports/*.json; do
+            if ! jq -e '.manifests[.job.correlator + "-gradle-build-tool"]' "$report" > /dev/null; then
+                echo "Did not find Gradle build tool reported as a dependency in $report"
+                exit 1
+            fi
+        done
+
+  dependency-submission-multiple-gradle-versions:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: Initialize integ-test
+      uses: ./.github/actions/init-integ-test
+
+    - id: gradle-8
+      uses: ./dependency-submission
+      with:
+        gradle-version: '8.14.3'
+        build-root-directory: .github/workflow-samples/no-wrapper
+    - id: gradle-9
+      uses: ./dependency-submission
+      with:
+        gradle-version: '9.0.0'
+        build-root-directory: .github/workflow-samples/no-wrapper
+    - name: Check each graph reports the Gradle version that generated it
+      shell: bash
+      run: |
+        check() {
+            if ! grep -q "pkg:maven/org.gradle/gradle-core@$2" "$1"; then
+                echo "Expected $1 to report Gradle $2 as a dependency"
+                cat "$1"
+                exit 1
+            fi
+        }
+        check "${{ steps.gradle-8.outputs.dependency-graph-file }}" 8.14.3
+        check "${{ steps.gradle-9.outputs.dependency-graph-file }}" 9.0.0
 
   dependency-submission-multiple-builds-upload:
     permissions:
@@ -261,10 +300,42 @@ jobs:
       with:
         java-version: ${{ matrix.java-version }}
     - name: Generate and submit dependencies
+      id: dependency-submission
       uses: ./dependency-submission
       with:
         gradle-version: ${{ matrix.gradle }}
         build-root-directory: .github/workflow-samples/no-wrapper${{ matrix.build-root-suffix }}
+    - name: Check Gradle build tool is reported as a dependency
+      shell: bash
+      run: |
+        report="${{ steps.dependency-submission.outputs.dependency-graph-file }}"
+        if [ ! -e "$report" ]; then
+            echo "Did not find generated dependency graph file"
+            exit 1
+        fi
+        buildTool=$(jq -c '.manifests[.job.correlator + "-gradle-build-tool"]' "$report")
+        echo "Reported build tool: $buildTool"
+        if ! echo "$buildTool" | jq -e --arg version "${{ matrix.gradle }}" '
+              .resolved == {
+                "gradle-core": {
+                  package_url: ("pkg:maven/org.gradle/gradle-core@" + $version),
+                  relationship: "direct",
+                  scope: "development"
+                }
+              }' > /dev/null; then
+            echo "Gradle ${{ matrix.gradle }} was not reported as expected in $report"
+            exit 1
+        fi
+        location=$(echo "$buildTool" | jq -r '.file.source_location')
+        dependencyLocation=$(jq -r '.manifests[.job.correlator].file.source_location' "$report")
+        if [ "$location" != "$dependencyLocation" ]; then
+            echo "Expected the build tool reported at '$dependencyLocation', but got '$location'"
+            exit 1
+        fi
+        if [ ! -f "$location" ]; then
+            echo "Manifest location '$location' is not a file in the repository"
+            exit 1
+        fi
 
   dependency-submission-with-setup-gradle:
     permissions:

--- a/sources/src/dependency-graph.ts
+++ b/sources/src/dependency-graph.ts
@@ -12,6 +12,7 @@ import {JobFailure} from './errors'
 import {DependencyGraphConfig, DependencyGraphOption, getGithubToken, getWorkspaceDirectory} from './configuration'
 
 const DEPENDENCY_GRAPH_PREFIX = 'dependency-graph_'
+const BUILD_TOOL_MANIFEST_SUFFIX = '-gradle-build-tool'
 
 export async function setup(config: DependencyGraphConfig): Promise<void> {
     const option = config.getDependencyGraphOption()
@@ -96,6 +97,7 @@ async function findAndSubmitDependencyGraphs(config: DependencyGraphConfig, uplo
     }
 
     const dependencyGraphFiles = await findDependencyGraphFiles()
+    addBuildToolDependency(dependencyGraphFiles)
     try {
         await submitDependencyGraphs(dependencyGraphFiles)
     } catch (e) {
@@ -118,7 +120,56 @@ async function findAndUploadDependencyGraphs(config: DependencyGraphConfig): Pro
         return
     }
 
-    await uploadDependencyGraphs(await findDependencyGraphFiles(), config)
+    const dependencyGraphFiles = await findDependencyGraphFiles()
+    addBuildToolDependency(dependencyGraphFiles)
+    await uploadDependencyGraphs(dependencyGraphFiles, config)
+}
+
+function addBuildToolDependency(dependencyGraphFiles: string[]): void {
+    for (const dependencyGraphFile of dependencyGraphFiles) {
+        const gradleVersion = readGradleVersionFor(dependencyGraphFile)
+        if (gradleVersion) {
+            addBuildToolManifest(dependencyGraphFile, gradleVersion)
+        } else {
+            core.info(`No Gradle version recorded for ${dependencyGraphFile}: build tool will not be reported`)
+        }
+    }
+}
+
+function readGradleVersionFor(dependencyGraphFile: string): string | undefined {
+    const versionFile = path.resolve(
+        process.env['RUNNER_TEMP']!,
+        '.gradle-actions',
+        'dependency-graph-versions',
+        path.basename(dependencyGraphFile)
+    )
+    return fs.existsSync(versionFile) ? fs.readFileSync(versionFile, 'utf8').trim() : undefined
+}
+
+function addBuildToolManifest(dependencyGraphFile: string, gradleVersion: string): void {
+    const snapshot = JSON.parse(fs.readFileSync(dependencyGraphFile, 'utf8'))
+    const manifestName = `${snapshot.job.correlator}${BUILD_TOOL_MANIFEST_SUFFIX}`
+
+    // reusing the existing location because action workflow location has a weird example, and wrapper location is not reported by dependabot for some reason
+    const file = Object.values(snapshot.manifests ?? {})
+        .map(manifest => manifest.file)
+        .find(manifestFile => manifestFile?.source_location)
+
+    snapshot.manifests = {
+        ...snapshot.manifests,
+        [manifestName]: {
+            name: manifestName,
+            ...(file ? {file} : {}),
+            resolved: {
+                'gradle-core': {
+                    package_url: `pkg:maven/org.gradle/gradle-core@${gradleVersion}`,
+                    relationship: 'direct',
+                    scope: 'development'
+                }
+            }
+        }
+    }
+    fs.writeFileSync(dependencyGraphFile, JSON.stringify(snapshot))
 }
 
 async function downloadDependencyGraphs(config: DependencyGraphConfig): Promise<string[]> {

--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph.init.gradle
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph.init.gradle
@@ -28,6 +28,8 @@ if (isTopLevelBuild) {
   }
 
   logger.lifecycle("Generating dependency graph into '${reportFile}'")
+
+  recordGradleVersionFor(reportFile)
 }
 
 apply from: 'gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy'
@@ -55,6 +57,17 @@ File getUniqueReportFile(String jobCorrelator) {
 
     // Could not determine unique job correlator
     return null
+}
+
+void recordGradleVersionFor(File reportFile) {
+    def runnerTemp = getVariable('RUNNER_TEMP')
+    if (!runnerTemp) {
+        return
+    }
+
+    def versionsDir = new File(runnerTemp, '.gradle-actions/dependency-graph-versions')
+    versionsDir.mkdirs()
+    new File(versionsDir, reportFile.name).text = GradleVersion.current().version
 }
 
 /**


### PR DESCRIPTION
Note: an alternative solution might be to move it to the plugin, but I assume it's not its responsibility

Sample reports:
* https://github.com/gradle/actions/actions/runs/33850280942#artifacts

Demo:
* https://github.com/ov7a/issue-management-test/security/dependabot/1