### PR TITLE
Bump dependency-graph-gradle-plugin to 1.5.0

### DIFF
--- a/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
+++ b/sources/src/resources/init-scripts/gradle-actions.github-dependency-graph-gradle-plugin-apply.groovy
@@ -6,7 +6,7 @@ buildscript {
   def pluginRepositoryUrl = getInputParam('gradle.plugin-repository.url') ?: 'https://plugins.gradle.org/m2'
   def pluginRepositoryUsername = getInputParam('gradle.plugin-repository.username')
   def pluginRepositoryPassword = getInputParam('gradle.plugin-repository.password')
-  def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.4.2'
+  def dependencyGraphPluginVersion = getInputParam('dependency-graph-plugin.version') ?: '1.5.0'
 
   logger.lifecycle("Resolving dependency graph plugin ${dependencyGraphPluginVersion} from plugin repository: ${pluginRepositoryUrl}")
   repositories {


### PR DESCRIPTION
Updates the default version of the [GitHub Dependency Graph Gradle Plugin](https://plugins.gradle.org/plugin/org.gradle.github-dependency-graph-gradle-plugin) applied by the `dependency-submission` init-script from `1.4.2` to `1.5.0`.

`1.5.0` is the latest version published to the Gradle Plugin Portal.

Users can still override this via the `dependency-graph-plugin.version` input parameter (`DEPENDENCY_GRAPH_PLUGIN_VERSION`), so this only changes the default.

## Notes

The init-script is read at runtime from `sources/src/resources` rather than being inlined into the bundle, so this single source change is the whole fix — no `dist` update is needed for the new version to take effect (CI refreshes `dist` as usual).

## Verification

- `npm run check` (prettier + eslint) passes
- `npm run test`: 489 passed. The 2 failing wrapper-validation suites are pre-existing network-dependent failures on this machine — confirmed identical on a clean tree with this change stashed
- Confirmed `1.5.0` is published to the plugin portal (and that a bogus version 404s, so the check is meaningful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)