### PR TITLE
Document the new Gradle signing key for dependency verification

### DIFF
--- a/docs/setup-gradle.md
+++ b/docs/setup-gradle.md
@@ -1040,5 +1040,19 @@ Each of the plugins is signed by Gradle, and you can simply add the following sn
       <trusting group="com.gradle"/>
       <trusting group="org.gradle"/>
    </trusted-key>
+   <trusted-key id="E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA">
+      <trusting group="org.gradle"/>
+   </trusted-key>
 </trusted-keys>
 ```
+
+Two keys are listed because Gradle has rotated its signing key, and the plugins applied by these actions
+are not all signed with the same one:
+- `E2879931BCA1A42E55F2D64DD9B2DFBD9F3298BA` is the current signing subkey. The
+  `github-dependency-graph-gradle-plugin` used for Dependency Graph generation is signed with it from
+  version `1.5.0` onward.
+- `7B79ADD11F8A779FE90FD3D0893A028475557671` is the older key, which has since been revoked. It is still
+  required: the Develocity Gradle plugin (`com.gradle`) is signed with it, as are `org.gradle` plugin
+  versions released before the rotation.
+
+Keep both entries unless you pin plugin versions and have confirmed which key each one uses.


### PR DESCRIPTION
Follow-up to #1069, which bumped the `github-dependency-graph-gradle-plugin` default to `1.5.0`.

`1.5.0` is signed with a **new** Gradle signing subkey, and the key currently documented in `docs/setup-gradle.md` has been revoked upstream. Without this docs change, the snippet we publish will fail dependency verification for Dependency Graph generation.

I verified the published signatures rather than relying on the changelog:

| Artifact | Issuer key | |
|---|---|---|
| `github-dependency-graph-gradle-plugin:1.5.0` | `D9B2DFBD9F3298BA` | new |
| `github-dependency-graph-gradle-plugin:1.4.2` | `893A028475557671` | old |
| `develocity-gradle-plugin:4.5.0` | `893A028475557671` | old |

So the docs now list **both** keys instead of swapping one for the other. The Develocity Gradle plugin (`com.gradle`) is still signed with the old key, so replacing it outright would have broken Develocity injection for builds with dependency verification enabled.

Docs-only change; no source or `dist` impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)